### PR TITLE
Add `SwampyerAutoReconnect`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ await this.wamp.open(new WebsocketJson('ws://localhost:8080/ws'), {
 // Use the `wamp` object for the WAMP operations
 ```
 
+More details about this class can be found [in the source code repository](docs/classes/index.Swampyer.md)
+
 ## `SwampyerAutoReconnect` class
 
 This is an alternate class that provides an automatic reconnection mechanism. It provides an `attemptOpen()` method in place of an `open()` method. If the connection can not be established on the first try or if the connection closes for some reason, then it will keep trying to reconnect until it succeeds or `wamp.close()` is called. 
@@ -75,6 +77,8 @@ wamp.openEvent.addEventListener(() => {
 })
 ```
 
+More details about this class can be found [in the source code repository](docs/classes/index.SwampyerAutoReconnect.md)
+
 ## Usage on nodejs
 
 Some adjustments need to be made in order to get this library working in a Nodejs environment:
@@ -106,3 +110,7 @@ If a custom transport method or serialization method is required, then the libra
 Custom transport providers must be a class that implements the `TransportProvider` interface. This ensures that the class implements all the functions that the library needs in order to make use of the transport provider.
 
 See the implementation of `WebsocketJson` to get an idea of how to implement your own custom transport provider.
+
+## Detailed documentation
+
+Detailed documentation can be found [in the source code repository](docs)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A lightweight WAMP client that implements the [WAMP v2 basic profile](https://wamp-proto.org/_static/gen/wamp_latest.html)
 
-The library is highly promise based. Almost all available operations return a promise.
+The library is highly promise based. Almost all available operations return a promise. However, it also allows for subscription to various events useful for monitoring the lifecycle of the WAMP connection.
 
-The library also provides Typescript types in the package itself.
+## `Swampyer` class
 
-## Basic usage
+Basic usage:
 
 ```ts
 import { Swampyer } from 'swampyer';
@@ -14,25 +14,66 @@ import { WebsocketJson } from 'swampyer/lib/transports/websocket_json';
 
 //...
 
-const wamp = new Swampyer({ realm: 'realm1' });
-await wamp.open(new WebsocketJson('ws://localhost:8080/ws'));
+const wamp = new Swampyer();
+
+// Unauthenticated connection
+await wamp.open(new WebsocketJson('ws://localhost:8080/ws'), { realm: 'realm1' });
+
+// Authenticated connection
+await this.wamp.open(new WebsocketJson('ws://localhost:8080/ws'), {
+  realm: 'realm1',
+  auth: {
+    authId: '<some username here>',
+    authMethods: ['ticket'],
+    onChallenge: method => '<authentication for the user>',
+  }
+});
 
 // Use the `wamp` object for the WAMP operations
 ```
 
-## Transport Providers
+## `SwampyerAutoReconnect` class
 
-The core library only concerns itself with sending and handling WAMP protocol messages. The method of transporting the WAMP messages to and from a WAMP server, and the serialization/deserialization process is left up to the user. The user must provide a transport provider to the `open()` method in order to establish a successful WAMP connection.
+This is an alternate class that provides an automatic reconnection mechanism. It provides an `attemptOpen()` method in place of an `open()` method. If the connection can not be established on the first try or if the connection closes for some reason, then it will keep trying to reconnect until it succeeds or `wamp.close()` is called. 
 
-The library optionally provides `WebsocketJson` which is a transport provider that allows connection over Websockets and uses `JSON` to serialize/deserialize the data. This transport provider should satisfy the needs for most users as most WAMP servers communicate over websocket and use the JSON format for the messages.
+Basic usage:
 
-### Custom Transport providers
+```ts
+import { Swampyer } from 'swampyer';
+import { WebsocketJson } from 'swampyer/lib/transports/websocket_json';
 
-If a custom transport method or serialization method is required, then the library allows the user to easily create their own custom transport providers.
+//...
 
-Custom transport providers must be a class that implements the `TransportProvider` interface. This ensures that the class implements all the functions that the library needs in order to make use of the transport provider.
+const wamp = new SwampyerAutoReconnect(
+  { realm: 'realm1' },
+  () => new WebsocketJson('ws://localhost:8080/ws')
+);
+wamp.attemptOpen();
 
-See the implementation of `WebsocketJson` to get an idea of how to implement your own custom transport provider.
+wamp.openEvent.addEventListener(() => {
+  // Use the `wamp` object for the WAMP operations
+})
+```
+
+By default, the delay between each successive reconnection attempt increases up to a maximum of 32000ms. If you want to have more control over the delay between each reconnection attempt then you can use something like the following
+
+```ts
+import { Swampyer } from 'swampyer';
+import { WebsocketJson } from 'swampyer/lib/transports/websocket_json';
+
+//...
+
+const wamp = new SwampyerAutoReconnect(
+  { realm: 'realm1' },
+  () => new WebsocketJson('ws://localhost:8080/ws'),
+  () => 1000 // The delay between each reconnection attempt will now be 1000ms
+);
+wamp.attemptOpen();
+
+wamp.openEvent.addEventListener(() => {
+  // Use the `wamp` object for the WAMP operations
+})
+```
 
 ## Usage on nodejs
 
@@ -51,3 +92,17 @@ Some adjustments need to be made in order to get this library working in a Nodej
   ```
 
   - This will allow `WebsocketJson` transport provider to work properly in the node environment
+
+## Transport Providers
+
+The core library only concerns itself with sending and handling WAMP protocol messages. The method of transporting the WAMP messages to and from a WAMP server, and the serialization/deserialization process is left up to the user. The user must provide a transport provider to the `open()` method in order to establish a successful WAMP connection.
+
+The library optionally provides `WebsocketJson` which is a transport provider that allows connection over Websockets and uses `JSON` to serialize/deserialize the data. This transport provider should satisfy the needs for most users as most WAMP servers communicate over websocket and use the JSON format for the messages.
+
+### Custom Transport providers
+
+If a custom transport method or serialization method is required, then the library allows the user to easily create their own custom transport providers.
+
+Custom transport providers must be a class that implements the `TransportProvider` interface. This ensures that the class implements all the functions that the library needs in order to make use of the transport provider.
+
+See the implementation of `WebsocketJson` to get an idea of how to implement your own custom transport provider.

--- a/docs/.nojekyll
+++ b/docs/.nojekyll
@@ -1,0 +1,1 @@
+TypeDoc added this file to prevent GitHub Pages from using Jekyll. You can turn off this behavior by setting the `githubPages` option to false.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,110 @@
+swampyer / [Modules](modules.md)
+
+# js-swampyer
+
+A lightweight WAMP client that implements the [WAMP v2 basic profile](https://wamp-proto.org/_static/gen/wamp_latest.html)
+
+The library is highly promise based. Almost all available operations return a promise. However, it also allows for subscription to various events useful for monitoring the lifecycle of the WAMP connection.
+
+## `Swampyer` class
+
+Basic usage:
+
+```ts
+import { Swampyer } from 'swampyer';
+import { WebsocketJson } from 'swampyer/lib/transports/websocket_json';
+
+//...
+
+const wamp = new Swampyer();
+
+// Unauthenticated connection
+await wamp.open(new WebsocketJson('ws://localhost:8080/ws'), { realm: 'realm1' });
+
+// Authenticated connection
+await this.wamp.open(new WebsocketJson('ws://localhost:8080/ws'), {
+  realm: 'realm1',
+  auth: {
+    authId: '<some username here>',
+    authMethods: ['ticket'],
+    onChallenge: method => '<authentication for the user>',
+  }
+});
+
+// Use the `wamp` object for the WAMP operations
+```
+
+## `SwampyerAutoReconnect` class
+
+This is an alternate class that provides an automatic reconnection mechanism. It provides an `attemptOpen()` method in place of an `open()` method. If the connection can not be established on the first try or if the connection closes for some reason, then it will keep trying to reconnect until it succeeds or `wamp.close()` is called. 
+
+Basic usage:
+
+```ts
+import { Swampyer } from 'swampyer';
+import { WebsocketJson } from 'swampyer/lib/transports/websocket_json';
+
+//...
+
+const wamp = new SwampyerAutoReconnect(
+  { realm: 'realm1' },
+  () => new WebsocketJson('ws://localhost:8080/ws')
+);
+wamp.attemptOpen();
+
+wamp.openEvent.addEventListener(() => {
+  // Use the `wamp` object for the WAMP operations
+})
+```
+
+By default, the delay between each successive reconnection attempt increases up to a maximum of 32000ms. If you want to have more control over the delay between each reconnection attempt then you can use something like the following
+
+```ts
+import { Swampyer } from 'swampyer';
+import { WebsocketJson } from 'swampyer/lib/transports/websocket_json';
+
+//...
+
+const wamp = new SwampyerAutoReconnect(
+  { realm: 'realm1' },
+  () => new WebsocketJson('ws://localhost:8080/ws'),
+  () => 1000 // The delay between each reconnection attempt will now be 1000ms
+);
+wamp.attemptOpen();
+
+wamp.openEvent.addEventListener(() => {
+  // Use the `wamp` object for the WAMP operations
+})
+```
+
+## Usage on nodejs
+
+Some adjustments need to be made in order to get this library working in a Nodejs environment:
+- Install a websocket implementation for nodejs (here we use [`ws`](https://www.npmjs.com/package/ws) as an examples)
+- Run the following at the start of you nodejs code
+
+  ```js
+  const ws = require('ws');
+
+  // Other imports ...
+
+  global.WebSocket = ws;
+
+  // Any code that uses Swampyer ...
+  ```
+
+  - This will allow `WebsocketJson` transport provider to work properly in the node environment
+
+## Transport Providers
+
+The core library only concerns itself with sending and handling WAMP protocol messages. The method of transporting the WAMP messages to and from a WAMP server, and the serialization/deserialization process is left up to the user. The user must provide a transport provider to the `open()` method in order to establish a successful WAMP connection.
+
+The library optionally provides `WebsocketJson` which is a transport provider that allows connection over Websockets and uses `JSON` to serialize/deserialize the data. This transport provider should satisfy the needs for most users as most WAMP servers communicate over websocket and use the JSON format for the messages.
+
+### Custom Transport providers
+
+If a custom transport method or serialization method is required, then the library allows the user to easily create their own custom transport providers.
+
+Custom transport providers must be a class that implements the `TransportProvider` interface. This ensures that the class implements all the functions that the library needs in order to make use of the transport provider.
+
+See the implementation of `WebsocketJson` to get an idea of how to implement your own custom transport provider.

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,8 @@ await this.wamp.open(new WebsocketJson('ws://localhost:8080/ws'), {
 // Use the `wamp` object for the WAMP operations
 ```
 
+More details about this class can be found [in the source code repository](docs/classes/index.Swampyer.md)
+
 ## `SwampyerAutoReconnect` class
 
 This is an alternate class that provides an automatic reconnection mechanism. It provides an `attemptOpen()` method in place of an `open()` method. If the connection can not be established on the first try or if the connection closes for some reason, then it will keep trying to reconnect until it succeeds or `wamp.close()` is called. 
@@ -77,6 +79,8 @@ wamp.openEvent.addEventListener(() => {
 })
 ```
 
+More details about this class can be found [in the source code repository](docs/classes/index.SwampyerAutoReconnect.md)
+
 ## Usage on nodejs
 
 Some adjustments need to be made in order to get this library working in a Nodejs environment:
@@ -108,3 +112,7 @@ If a custom transport method or serialization method is required, then the libra
 Custom transport providers must be a class that implements the `TransportProvider` interface. This ensures that the class implements all the functions that the library needs in order to make use of the transport provider.
 
 See the implementation of `WebsocketJson` to get an idea of how to implement your own custom transport provider.
+
+## Detailed documentation
+
+Detailed documentation can be found [in the source code repository](docs)

--- a/docs/classes/index.AbortError.md
+++ b/docs/classes/index.AbortError.md
@@ -1,0 +1,180 @@
+[swampyer](../README.md) / [Modules](../modules.md) / [index](../modules/index.md) / AbortError
+
+# Class: AbortError
+
+[index](../modules/index.md).AbortError
+
+## Hierarchy
+
+- [`SwampyerError`](index.SwampyerError.md)
+
+  ↳ **`AbortError`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](index.AbortError.md#constructor)
+
+### Properties
+
+- [details](index.AbortError.md#details)
+- [message](index.AbortError.md#message)
+- [name](index.AbortError.md#name)
+- [reason](index.AbortError.md#reason)
+- [stack](index.AbortError.md#stack)
+- [prepareStackTrace](index.AbortError.md#preparestacktrace)
+- [stackTraceLimit](index.AbortError.md#stacktracelimit)
+
+### Methods
+
+- [captureStackTrace](index.AbortError.md#capturestacktrace)
+
+## Constructors
+
+### constructor
+
+• **new AbortError**(`reason`, `details`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `reason` | `string` |
+| `details` | `Object` |
+
+#### Overrides
+
+[SwampyerError](index.SwampyerError.md).[constructor](index.SwampyerError.md#constructor)
+
+#### Defined in
+
+[src/errors.ts:21](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/errors.ts#L21)
+
+## Properties
+
+### details
+
+• `Readonly` **details**: `Object`
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[message](index.SwampyerError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:974
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[name](index.SwampyerError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:973
+
+___
+
+### reason
+
+• `Readonly` **reason**: `string`
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[stack](index.SwampyerError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:975
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`see`** https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[prepareStackTrace](index.SwampyerError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[stackTraceLimit](index.SwampyerError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[captureStackTrace](index.SwampyerError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:4

--- a/docs/classes/index.AbortError.md
+++ b/docs/classes/index.AbortError.md
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[src/errors.ts:21](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/errors.ts#L21)
+[src/errors.ts:21](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/errors.ts#L21)
 
 ## Properties
 

--- a/docs/classes/index.AbortError.md
+++ b/docs/classes/index.AbortError.md
@@ -47,10 +47,6 @@
 
 [SwampyerError](index.SwampyerError.md).[constructor](index.SwampyerError.md#constructor)
 
-#### Defined in
-
-[src/errors.ts:21](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/errors.ts#L21)
-
 ## Properties
 
 ### details
@@ -67,10 +63,6 @@ ___
 
 [SwampyerError](index.SwampyerError.md).[message](index.SwampyerError.md#message)
 
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:974
-
 ___
 
 ### name
@@ -80,10 +72,6 @@ ___
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[name](index.SwampyerError.md#name)
-
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:973
 
 ___
 
@@ -100,10 +88,6 @@ ___
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[stack](index.SwampyerError.md#stack)
-
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:975
 
 ___
 
@@ -134,10 +118,6 @@ Optional override for formatting stack traces
 
 [SwampyerError](index.SwampyerError.md).[prepareStackTrace](index.SwampyerError.md#preparestacktrace)
 
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:11
-
 ___
 
 ### stackTraceLimit
@@ -147,10 +127,6 @@ ___
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[stackTraceLimit](index.SwampyerError.md#stacktracelimit)
-
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:13
 
 ## Methods
 
@@ -174,7 +150,3 @@ Create .stack property on a target object
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[captureStackTrace](index.SwampyerError.md#capturestacktrace)
-
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:4

--- a/docs/classes/index.ConnectionClosedError.md
+++ b/docs/classes/index.ConnectionClosedError.md
@@ -47,10 +47,6 @@
 
 [SwampyerError](index.SwampyerError.md).[constructor](index.SwampyerError.md#constructor)
 
-#### Defined in
-
-[src/errors.ts:31](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/errors.ts#L31)
-
 ## Properties
 
 ### details
@@ -67,10 +63,6 @@ ___
 
 [SwampyerError](index.SwampyerError.md).[message](index.SwampyerError.md#message)
 
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:974
-
 ___
 
 ### name
@@ -80,10 +72,6 @@ ___
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[name](index.SwampyerError.md#name)
-
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:973
 
 ___
 
@@ -100,10 +88,6 @@ ___
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[stack](index.SwampyerError.md#stack)
-
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:975
 
 ___
 
@@ -134,10 +118,6 @@ Optional override for formatting stack traces
 
 [SwampyerError](index.SwampyerError.md).[prepareStackTrace](index.SwampyerError.md#preparestacktrace)
 
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:11
-
 ___
 
 ### stackTraceLimit
@@ -147,10 +127,6 @@ ___
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[stackTraceLimit](index.SwampyerError.md#stacktracelimit)
-
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:13
 
 ## Methods
 
@@ -174,7 +150,3 @@ Create .stack property on a target object
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[captureStackTrace](index.SwampyerError.md#capturestacktrace)
-
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:4

--- a/docs/classes/index.ConnectionClosedError.md
+++ b/docs/classes/index.ConnectionClosedError.md
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[src/errors.ts:31](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/errors.ts#L31)
+[src/errors.ts:31](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/errors.ts#L31)
 
 ## Properties
 

--- a/docs/classes/index.ConnectionClosedError.md
+++ b/docs/classes/index.ConnectionClosedError.md
@@ -1,0 +1,180 @@
+[swampyer](../README.md) / [Modules](../modules.md) / [index](../modules/index.md) / ConnectionClosedError
+
+# Class: ConnectionClosedError
+
+[index](../modules/index.md).ConnectionClosedError
+
+## Hierarchy
+
+- [`SwampyerError`](index.SwampyerError.md)
+
+  ↳ **`ConnectionClosedError`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](index.ConnectionClosedError.md#constructor)
+
+### Properties
+
+- [details](index.ConnectionClosedError.md#details)
+- [message](index.ConnectionClosedError.md#message)
+- [name](index.ConnectionClosedError.md#name)
+- [reason](index.ConnectionClosedError.md#reason)
+- [stack](index.ConnectionClosedError.md#stack)
+- [prepareStackTrace](index.ConnectionClosedError.md#preparestacktrace)
+- [stackTraceLimit](index.ConnectionClosedError.md#stacktracelimit)
+
+### Methods
+
+- [captureStackTrace](index.ConnectionClosedError.md#capturestacktrace)
+
+## Constructors
+
+### constructor
+
+• **new ConnectionClosedError**(`reason`, `details`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `reason` | `string` |
+| `details` | `Object` |
+
+#### Overrides
+
+[SwampyerError](index.SwampyerError.md).[constructor](index.SwampyerError.md#constructor)
+
+#### Defined in
+
+[src/errors.ts:31](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/errors.ts#L31)
+
+## Properties
+
+### details
+
+• `Readonly` **details**: `Object`
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[message](index.SwampyerError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:974
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[name](index.SwampyerError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:973
+
+___
+
+### reason
+
+• `Readonly` **reason**: `string`
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[stack](index.SwampyerError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:975
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`see`** https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[prepareStackTrace](index.SwampyerError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[stackTraceLimit](index.SwampyerError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[captureStackTrace](index.SwampyerError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:4

--- a/docs/classes/index.ConnectionOpenError.md
+++ b/docs/classes/index.ConnectionOpenError.md
@@ -44,10 +44,6 @@
 
 [SwampyerError](index.SwampyerError.md).[constructor](index.SwampyerError.md#constructor)
 
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:979
-
 ## Properties
 
 ### message
@@ -57,10 +53,6 @@ node_modules/typescript/lib/lib.es5.d.ts:979
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[message](index.SwampyerError.md#message)
-
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:974
 
 ___
 
@@ -72,10 +64,6 @@ ___
 
 [SwampyerError](index.SwampyerError.md).[name](index.SwampyerError.md#name)
 
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:973
-
 ___
 
 ### stack
@@ -85,10 +73,6 @@ ___
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[stack](index.SwampyerError.md#stack)
-
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:975
 
 ___
 
@@ -119,10 +103,6 @@ Optional override for formatting stack traces
 
 [SwampyerError](index.SwampyerError.md).[prepareStackTrace](index.SwampyerError.md#preparestacktrace)
 
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:11
-
 ___
 
 ### stackTraceLimit
@@ -132,10 +112,6 @@ ___
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[stackTraceLimit](index.SwampyerError.md#stacktracelimit)
-
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:13
 
 ## Methods
 
@@ -159,7 +135,3 @@ Create .stack property on a target object
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[captureStackTrace](index.SwampyerError.md#capturestacktrace)
-
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:4

--- a/docs/classes/index.ConnectionOpenError.md
+++ b/docs/classes/index.ConnectionOpenError.md
@@ -1,0 +1,165 @@
+[swampyer](../README.md) / [Modules](../modules.md) / [index](../modules/index.md) / ConnectionOpenError
+
+# Class: ConnectionOpenError
+
+[index](../modules/index.md).ConnectionOpenError
+
+## Hierarchy
+
+- [`SwampyerError`](index.SwampyerError.md)
+
+  ↳ **`ConnectionOpenError`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](index.ConnectionOpenError.md#constructor)
+
+### Properties
+
+- [message](index.ConnectionOpenError.md#message)
+- [name](index.ConnectionOpenError.md#name)
+- [stack](index.ConnectionOpenError.md#stack)
+- [prepareStackTrace](index.ConnectionOpenError.md#preparestacktrace)
+- [stackTraceLimit](index.ConnectionOpenError.md#stacktracelimit)
+
+### Methods
+
+- [captureStackTrace](index.ConnectionOpenError.md#capturestacktrace)
+
+## Constructors
+
+### constructor
+
+• **new ConnectionOpenError**(`message?`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message?` | `string` |
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[constructor](index.SwampyerError.md#constructor)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:979
+
+## Properties
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[message](index.SwampyerError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:974
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[name](index.SwampyerError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:973
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[stack](index.SwampyerError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:975
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`see`** https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[prepareStackTrace](index.SwampyerError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[stackTraceLimit](index.SwampyerError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[captureStackTrace](index.SwampyerError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:4

--- a/docs/classes/index.Swampyer.md
+++ b/docs/classes/index.Swampyer.md
@@ -56,7 +56,7 @@
 
 #### Defined in
 
-[src/swampyer.ts:29](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L29)
+[src/swampyer.ts:29](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L29)
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:28](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L28)
+[src/swampyer.ts:28](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L28)
 
 ## Accessors
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:31](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L31)
+[src/swampyer.ts:31](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L31)
 
 ## Methods
 
@@ -109,7 +109,7 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:155](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L155)
+[src/swampyer.ts:155](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L155)
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:116](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L116)
+[src/swampyer.ts:116](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L116)
 
 ___
 
@@ -151,7 +151,7 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:35](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L35)
+[src/swampyer.ts:35](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L35)
 
 ___
 
@@ -174,7 +174,7 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:180](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L180)
+[src/swampyer.ts:180](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L180)
 
 ___
 
@@ -196,7 +196,7 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:137](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L137)
+[src/swampyer.ts:137](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L137)
 
 ___
 
@@ -218,7 +218,7 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:164](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L164)
+[src/swampyer.ts:164](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L164)
 
 ___
 
@@ -238,7 +238,7 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:147](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L147)
+[src/swampyer.ts:147](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L147)
 
 ___
 
@@ -258,4 +258,4 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:173](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L173)
+[src/swampyer.ts:173](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L173)

--- a/docs/classes/index.Swampyer.md
+++ b/docs/classes/index.Swampyer.md
@@ -1,0 +1,261 @@
+[swampyer](../README.md) / [Modules](../modules.md) / [index](../modules/index.md) / Swampyer
+
+# Class: Swampyer
+
+[index](../modules/index.md).Swampyer
+
+## Hierarchy
+
+- **`Swampyer`**
+
+  ↳ [`SwampyerAutoReconnect`](index.SwampyerAutoReconnect.md)
+
+## Table of contents
+
+### Constructors
+
+- [constructor](index.Swampyer.md#constructor)
+
+### Properties
+
+- [closeEvent](index.Swampyer.md#closeevent)
+- [openEvent](index.Swampyer.md#openevent)
+
+### Accessors
+
+- [isOpen](index.Swampyer.md#isopen)
+
+### Methods
+
+- [call](index.Swampyer.md#call)
+- [close](index.Swampyer.md#close)
+- [open](index.Swampyer.md#open)
+- [publish](index.Swampyer.md#publish)
+- [register](index.Swampyer.md#register)
+- [subscribe](index.Swampyer.md#subscribe)
+- [unregister](index.Swampyer.md#unregister)
+- [unsubscribe](index.Swampyer.md#unsubscribe)
+
+## Constructors
+
+### constructor
+
+• **new Swampyer**()
+
+## Properties
+
+### closeEvent
+
+• `Readonly` **closeEvent**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `addEventListener` | (`callback`: (...`args`: [reason: CloseReason, details: CloseDetails]) => `void`) => () => `void` |
+
+#### Defined in
+
+[src/swampyer.ts:29](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L29)
+
+___
+
+### openEvent
+
+• `Readonly` **openEvent**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `addEventListener` | (`callback`: (...`args`: [[`WelcomeDetails`](../modules/index.md#welcomedetails)]) => `void`) => () => `void` |
+
+#### Defined in
+
+[src/swampyer.ts:28](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L28)
+
+## Accessors
+
+### isOpen
+
+• `get` **isOpen**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Defined in
+
+[src/swampyer.ts:31](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L31)
+
+## Methods
+
+### call
+
+▸ **call**(`uri`, `args?`, `kwargs?`, `options?`): `Promise`<`unknown`\>
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `uri` | `string` | `undefined` |
+| `args` | `unknown`[] | `[]` |
+| `kwargs` | `Object` | `{}` |
+| `options` | `CommonOptions` | `{}` |
+
+#### Returns
+
+`Promise`<`unknown`\>
+
+#### Defined in
+
+[src/swampyer.ts:155](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L155)
+
+___
+
+### close
+
+▸ **close**(`reason?`, `message?`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `reason` | `string` | `'wamp.close.system_shutdown'` |
+| `message?` | `string` | `undefined` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[src/swampyer.ts:116](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L116)
+
+___
+
+### open
+
+▸ **open**(`transportProvider`, `options`): `Promise`<[`WelcomeDetails`](../modules/index.md#welcomedetails)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `transportProvider` | [`TransportProvider`](../interfaces/transports_transport.TransportProvider.md) |
+| `options` | [`OpenOptions`](../interfaces/index.OpenOptions.md) |
+
+#### Returns
+
+`Promise`<[`WelcomeDetails`](../modules/index.md#welcomedetails)\>
+
+#### Defined in
+
+[src/swampyer.ts:35](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L35)
+
+___
+
+### publish
+
+▸ **publish**(`uri`, `args?`, `kwargs?`, `options?`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `uri` | `string` | `undefined` |
+| `args` | `unknown`[] | `[]` |
+| `kwargs` | `Object` | `{}` |
+| `options` | [`PublishOptions`](../interfaces/index.PublishOptions.md) | `{}` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[src/swampyer.ts:180](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L180)
+
+___
+
+### register
+
+▸ **register**(`uri`, `handler`, `options?`): `Promise`<`number`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `uri` | `string` |
+| `handler` | [`RegistrationHandler`](../modules/index.md#registrationhandler) |
+| `options` | `CommonOptions` |
+
+#### Returns
+
+`Promise`<`number`\>
+
+#### Defined in
+
+[src/swampyer.ts:137](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L137)
+
+___
+
+### subscribe
+
+▸ **subscribe**(`uri`, `handler`, `options?`): `Promise`<`number`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `uri` | `string` |
+| `handler` | [`SubscriptionHandler`](../modules/index.md#subscriptionhandler) |
+| `options` | `CommonOptions` |
+
+#### Returns
+
+`Promise`<`number`\>
+
+#### Defined in
+
+[src/swampyer.ts:164](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L164)
+
+___
+
+### unregister
+
+▸ **unregister**(`registrationId`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `registrationId` | `number` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[src/swampyer.ts:147](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L147)
+
+___
+
+### unsubscribe
+
+▸ **unsubscribe**(`subscriptionId`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `subscriptionId` | `number` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[src/swampyer.ts:173](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L173)

--- a/docs/classes/index.Swampyer.md
+++ b/docs/classes/index.Swampyer.md
@@ -54,10 +54,6 @@
 | :------ | :------ |
 | `addEventListener` | (`callback`: (...`args`: [reason: CloseReason, details: CloseDetails]) => `void`) => () => `void` |
 
-#### Defined in
-
-[src/swampyer.ts:29](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L29)
-
 ___
 
 ### openEvent
@@ -70,10 +66,6 @@ ___
 | :------ | :------ |
 | `addEventListener` | (`callback`: (...`args`: [[`WelcomeDetails`](../modules/index.md#welcomedetails)]) => `void`) => () => `void` |
 
-#### Defined in
-
-[src/swampyer.ts:28](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L28)
-
 ## Accessors
 
 ### isOpen
@@ -83,10 +75,6 @@ ___
 #### Returns
 
 `boolean`
-
-#### Defined in
-
-[src/swampyer.ts:31](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L31)
 
 ## Methods
 
@@ -107,10 +95,6 @@ ___
 
 `Promise`<`unknown`\>
 
-#### Defined in
-
-[src/swampyer.ts:155](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L155)
-
 ___
 
 ### close
@@ -128,10 +112,6 @@ ___
 
 `Promise`<`void`\>
 
-#### Defined in
-
-[src/swampyer.ts:116](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L116)
-
 ___
 
 ### open
@@ -148,10 +128,6 @@ ___
 #### Returns
 
 `Promise`<[`WelcomeDetails`](../modules/index.md#welcomedetails)\>
-
-#### Defined in
-
-[src/swampyer.ts:35](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L35)
 
 ___
 
@@ -172,10 +148,6 @@ ___
 
 `Promise`<`void`\>
 
-#### Defined in
-
-[src/swampyer.ts:180](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L180)
-
 ___
 
 ### register
@@ -193,10 +165,6 @@ ___
 #### Returns
 
 `Promise`<`number`\>
-
-#### Defined in
-
-[src/swampyer.ts:137](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L137)
 
 ___
 
@@ -216,10 +184,6 @@ ___
 
 `Promise`<`number`\>
 
-#### Defined in
-
-[src/swampyer.ts:164](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L164)
-
 ___
 
 ### unregister
@@ -236,10 +200,6 @@ ___
 
 `Promise`<`void`\>
 
-#### Defined in
-
-[src/swampyer.ts:147](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L147)
-
 ___
 
 ### unsubscribe
@@ -255,7 +215,3 @@ ___
 #### Returns
 
 `Promise`<`void`\>
-
-#### Defined in
-
-[src/swampyer.ts:173](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L173)

--- a/docs/classes/index.SwampyerAutoReconnect.md
+++ b/docs/classes/index.SwampyerAutoReconnect.md
@@ -55,10 +55,6 @@
 
 [Swampyer](index.Swampyer.md).[constructor](index.Swampyer.md#constructor)
 
-#### Defined in
-
-[src/swampyer_auto_reconnect.ts:15](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer_auto_reconnect.ts#L15)
-
 ## Properties
 
 ### closeEvent
@@ -74,10 +70,6 @@
 #### Inherited from
 
 [Swampyer](index.Swampyer.md).[closeEvent](index.Swampyer.md#closeevent)
-
-#### Defined in
-
-[src/swampyer.ts:29](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L29)
 
 ___
 
@@ -95,10 +87,6 @@ ___
 
 [Swampyer](index.Swampyer.md).[openEvent](index.Swampyer.md#openevent)
 
-#### Defined in
-
-[src/swampyer.ts:28](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L28)
-
 ## Accessors
 
 ### isOpen
@@ -113,10 +101,6 @@ ___
 
 Swampyer.isOpen
 
-#### Defined in
-
-[src/swampyer.ts:31](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L31)
-
 ## Methods
 
 ### attemptOpen
@@ -129,10 +113,6 @@ open operation fails or if the connection closes at any point.
 #### Returns
 
 `void`
-
-#### Defined in
-
-[src/swampyer_auto_reconnect.ts:51](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer_auto_reconnect.ts#L51)
 
 ___
 
@@ -157,10 +137,6 @@ ___
 
 [Swampyer](index.Swampyer.md).[call](index.Swampyer.md#call)
 
-#### Defined in
-
-[src/swampyer.ts:155](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L155)
-
 ___
 
 ### close
@@ -181,10 +157,6 @@ ___
 #### Inherited from
 
 [Swampyer](index.Swampyer.md).[close](index.Swampyer.md#close)
-
-#### Defined in
-
-[src/swampyer.ts:116](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L116)
 
 ___
 
@@ -207,10 +179,6 @@ This function is not supported on this class. Please use [attemptOpen](index.Swa
 #### Overrides
 
 [Swampyer](index.Swampyer.md).[open](index.Swampyer.md#open)
-
-#### Defined in
-
-[src/swampyer_auto_reconnect.ts:43](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer_auto_reconnect.ts#L43)
 
 ___
 
@@ -235,10 +203,6 @@ ___
 
 [Swampyer](index.Swampyer.md).[publish](index.Swampyer.md#publish)
 
-#### Defined in
-
-[src/swampyer.ts:180](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L180)
-
 ___
 
 ### register
@@ -260,10 +224,6 @@ ___
 #### Inherited from
 
 [Swampyer](index.Swampyer.md).[register](index.Swampyer.md#register)
-
-#### Defined in
-
-[src/swampyer.ts:137](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L137)
 
 ___
 
@@ -287,10 +247,6 @@ ___
 
 [Swampyer](index.Swampyer.md).[subscribe](index.Swampyer.md#subscribe)
 
-#### Defined in
-
-[src/swampyer.ts:164](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L164)
-
 ___
 
 ### unregister
@@ -311,10 +267,6 @@ ___
 
 [Swampyer](index.Swampyer.md).[unregister](index.Swampyer.md#unregister)
 
-#### Defined in
-
-[src/swampyer.ts:147](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L147)
-
 ___
 
 ### unsubscribe
@@ -334,7 +286,3 @@ ___
 #### Inherited from
 
 [Swampyer](index.Swampyer.md).[unsubscribe](index.Swampyer.md#unsubscribe)
-
-#### Defined in
-
-[src/swampyer.ts:173](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L173)

--- a/docs/classes/index.SwampyerAutoReconnect.md
+++ b/docs/classes/index.SwampyerAutoReconnect.md
@@ -1,0 +1,340 @@
+[swampyer](../README.md) / [Modules](../modules.md) / [index](../modules/index.md) / SwampyerAutoReconnect
+
+# Class: SwampyerAutoReconnect
+
+[index](../modules/index.md).SwampyerAutoReconnect
+
+## Hierarchy
+
+- [`Swampyer`](index.Swampyer.md)
+
+  ↳ **`SwampyerAutoReconnect`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](index.SwampyerAutoReconnect.md#constructor)
+
+### Properties
+
+- [closeEvent](index.SwampyerAutoReconnect.md#closeevent)
+- [openEvent](index.SwampyerAutoReconnect.md#openevent)
+
+### Accessors
+
+- [isOpen](index.SwampyerAutoReconnect.md#isopen)
+
+### Methods
+
+- [attemptOpen](index.SwampyerAutoReconnect.md#attemptopen)
+- [call](index.SwampyerAutoReconnect.md#call)
+- [close](index.SwampyerAutoReconnect.md#close)
+- [open](index.SwampyerAutoReconnect.md#open)
+- [publish](index.SwampyerAutoReconnect.md#publish)
+- [register](index.SwampyerAutoReconnect.md#register)
+- [subscribe](index.SwampyerAutoReconnect.md#subscribe)
+- [unregister](index.SwampyerAutoReconnect.md#unregister)
+- [unsubscribe](index.SwampyerAutoReconnect.md#unsubscribe)
+
+## Constructors
+
+### constructor
+
+• **new SwampyerAutoReconnect**(`options`, `getTransportProvider`, `getReconnectionDelay?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `options` | [`OpenOptions`](../interfaces/index.OpenOptions.md) | `undefined` |
+| `getTransportProvider` | (`attempt`: `number`, ...`closeData`: [closeReason: CloseReason, closeDetails: CloseDetails]) => ``null`` \| [`TransportProvider`](../interfaces/transports_transport.TransportProvider.md) | `undefined` |
+| `getReconnectionDelay` | (`attempt`: `number`, ...`closeData`: `CloseEventData`) => ``null`` \| `number` | `defaultGetReconnectionDelay` |
+
+#### Overrides
+
+[Swampyer](index.Swampyer.md).[constructor](index.Swampyer.md#constructor)
+
+#### Defined in
+
+[src/swampyer_auto_reconnect.ts:15](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer_auto_reconnect.ts#L15)
+
+## Properties
+
+### closeEvent
+
+• `Readonly` **closeEvent**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `addEventListener` | (`callback`: (...`args`: [reason: CloseReason, details: CloseDetails]) => `void`) => () => `void` |
+
+#### Inherited from
+
+[Swampyer](index.Swampyer.md).[closeEvent](index.Swampyer.md#closeevent)
+
+#### Defined in
+
+[src/swampyer.ts:29](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L29)
+
+___
+
+### openEvent
+
+• `Readonly` **openEvent**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `addEventListener` | (`callback`: (...`args`: [[`WelcomeDetails`](../modules/index.md#welcomedetails)]) => `void`) => () => `void` |
+
+#### Inherited from
+
+[Swampyer](index.Swampyer.md).[openEvent](index.Swampyer.md#openevent)
+
+#### Defined in
+
+[src/swampyer.ts:28](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L28)
+
+## Accessors
+
+### isOpen
+
+• `get` **isOpen**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+Swampyer.isOpen
+
+#### Defined in
+
+[src/swampyer.ts:31](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L31)
+
+## Methods
+
+### attemptOpen
+
+▸ **attemptOpen**(): `void`
+
+Starts the process of openinig the WAMP connection. It will handle auto reconnection if the
+open operation fails or if the connection closes at any point.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[src/swampyer_auto_reconnect.ts:51](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer_auto_reconnect.ts#L51)
+
+___
+
+### call
+
+▸ **call**(`uri`, `args?`, `kwargs?`, `options?`): `Promise`<`unknown`\>
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `uri` | `string` | `undefined` |
+| `args` | `unknown`[] | `[]` |
+| `kwargs` | `Object` | `{}` |
+| `options` | `CommonOptions` | `{}` |
+
+#### Returns
+
+`Promise`<`unknown`\>
+
+#### Inherited from
+
+[Swampyer](index.Swampyer.md).[call](index.Swampyer.md#call)
+
+#### Defined in
+
+[src/swampyer.ts:155](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L155)
+
+___
+
+### close
+
+▸ **close**(`reason?`, `message?`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `reason` | `string` | `'wamp.close.system_shutdown'` |
+| `message?` | `string` | `undefined` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+[Swampyer](index.Swampyer.md).[close](index.Swampyer.md#close)
+
+#### Defined in
+
+[src/swampyer.ts:116](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L116)
+
+___
+
+### open
+
+▸ **open**(...`args`): `Promise`<[`WelcomeDetails`](../modules/index.md#welcomedetails)\>
+
+This function is not supported on this class. Please use [attemptOpen](index.SwampyerAutoReconnect.md#attemptopen) instead.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [transportProvider: TransportProvider, options: OpenOptions] |
+
+#### Returns
+
+`Promise`<[`WelcomeDetails`](../modules/index.md#welcomedetails)\>
+
+#### Overrides
+
+[Swampyer](index.Swampyer.md).[open](index.Swampyer.md#open)
+
+#### Defined in
+
+[src/swampyer_auto_reconnect.ts:43](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer_auto_reconnect.ts#L43)
+
+___
+
+### publish
+
+▸ **publish**(`uri`, `args?`, `kwargs?`, `options?`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `uri` | `string` | `undefined` |
+| `args` | `unknown`[] | `[]` |
+| `kwargs` | `Object` | `{}` |
+| `options` | [`PublishOptions`](../interfaces/index.PublishOptions.md) | `{}` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+[Swampyer](index.Swampyer.md).[publish](index.Swampyer.md#publish)
+
+#### Defined in
+
+[src/swampyer.ts:180](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L180)
+
+___
+
+### register
+
+▸ **register**(`uri`, `handler`, `options?`): `Promise`<`number`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `uri` | `string` |
+| `handler` | [`RegistrationHandler`](../modules/index.md#registrationhandler) |
+| `options` | `CommonOptions` |
+
+#### Returns
+
+`Promise`<`number`\>
+
+#### Inherited from
+
+[Swampyer](index.Swampyer.md).[register](index.Swampyer.md#register)
+
+#### Defined in
+
+[src/swampyer.ts:137](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L137)
+
+___
+
+### subscribe
+
+▸ **subscribe**(`uri`, `handler`, `options?`): `Promise`<`number`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `uri` | `string` |
+| `handler` | [`SubscriptionHandler`](../modules/index.md#subscriptionhandler) |
+| `options` | `CommonOptions` |
+
+#### Returns
+
+`Promise`<`number`\>
+
+#### Inherited from
+
+[Swampyer](index.Swampyer.md).[subscribe](index.Swampyer.md#subscribe)
+
+#### Defined in
+
+[src/swampyer.ts:164](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L164)
+
+___
+
+### unregister
+
+▸ **unregister**(`registrationId`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `registrationId` | `number` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+[Swampyer](index.Swampyer.md).[unregister](index.Swampyer.md#unregister)
+
+#### Defined in
+
+[src/swampyer.ts:147](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L147)
+
+___
+
+### unsubscribe
+
+▸ **unsubscribe**(`subscriptionId`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `subscriptionId` | `number` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+[Swampyer](index.Swampyer.md).[unsubscribe](index.Swampyer.md#unsubscribe)
+
+#### Defined in
+
+[src/swampyer.ts:173](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L173)

--- a/docs/classes/index.SwampyerAutoReconnect.md
+++ b/docs/classes/index.SwampyerAutoReconnect.md
@@ -57,7 +57,7 @@
 
 #### Defined in
 
-[src/swampyer_auto_reconnect.ts:15](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer_auto_reconnect.ts#L15)
+[src/swampyer_auto_reconnect.ts:15](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer_auto_reconnect.ts#L15)
 
 ## Properties
 
@@ -77,7 +77,7 @@
 
 #### Defined in
 
-[src/swampyer.ts:29](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L29)
+[src/swampyer.ts:29](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L29)
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:28](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L28)
+[src/swampyer.ts:28](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L28)
 
 ## Accessors
 
@@ -115,7 +115,7 @@ Swampyer.isOpen
 
 #### Defined in
 
-[src/swampyer.ts:31](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L31)
+[src/swampyer.ts:31](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L31)
 
 ## Methods
 
@@ -132,7 +132,7 @@ open operation fails or if the connection closes at any point.
 
 #### Defined in
 
-[src/swampyer_auto_reconnect.ts:51](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer_auto_reconnect.ts#L51)
+[src/swampyer_auto_reconnect.ts:51](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer_auto_reconnect.ts#L51)
 
 ___
 
@@ -159,7 +159,7 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:155](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L155)
+[src/swampyer.ts:155](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L155)
 
 ___
 
@@ -184,7 +184,7 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:116](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L116)
+[src/swampyer.ts:116](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L116)
 
 ___
 
@@ -210,7 +210,7 @@ This function is not supported on this class. Please use [attemptOpen](index.Swa
 
 #### Defined in
 
-[src/swampyer_auto_reconnect.ts:43](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer_auto_reconnect.ts#L43)
+[src/swampyer_auto_reconnect.ts:43](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer_auto_reconnect.ts#L43)
 
 ___
 
@@ -237,7 +237,7 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:180](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L180)
+[src/swampyer.ts:180](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L180)
 
 ___
 
@@ -263,7 +263,7 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:137](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L137)
+[src/swampyer.ts:137](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L137)
 
 ___
 
@@ -289,7 +289,7 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:164](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L164)
+[src/swampyer.ts:164](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L164)
 
 ___
 
@@ -313,7 +313,7 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:147](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L147)
+[src/swampyer.ts:147](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L147)
 
 ___
 
@@ -337,4 +337,4 @@ ___
 
 #### Defined in
 
-[src/swampyer.ts:173](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/swampyer.ts#L173)
+[src/swampyer.ts:173](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/swampyer.ts#L173)

--- a/docs/classes/index.SwampyerError.md
+++ b/docs/classes/index.SwampyerError.md
@@ -58,10 +58,6 @@
 
 Error.constructor
 
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:979
-
 ## Properties
 
 ### message
@@ -71,10 +67,6 @@ node_modules/typescript/lib/lib.es5.d.ts:979
 #### Inherited from
 
 Error.message
-
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:974
 
 ___
 
@@ -86,10 +78,6 @@ ___
 
 Error.name
 
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:973
-
 ___
 
 ### stack
@@ -99,10 +87,6 @@ ___
 #### Inherited from
 
 Error.stack
-
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:975
 
 ___
 
@@ -133,10 +117,6 @@ Optional override for formatting stack traces
 
 Error.prepareStackTrace
 
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:11
-
 ___
 
 ### stackTraceLimit
@@ -146,10 +126,6 @@ ___
 #### Inherited from
 
 Error.stackTraceLimit
-
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:13
 
 ## Methods
 
@@ -173,7 +149,3 @@ Create .stack property on a target object
 #### Inherited from
 
 Error.captureStackTrace
-
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:4

--- a/docs/classes/index.SwampyerError.md
+++ b/docs/classes/index.SwampyerError.md
@@ -1,0 +1,179 @@
+[swampyer](../README.md) / [Modules](../modules.md) / [index](../modules/index.md) / SwampyerError
+
+# Class: SwampyerError
+
+[index](../modules/index.md).SwampyerError
+
+## Hierarchy
+
+- `Error`
+
+  ↳ **`SwampyerError`**
+
+  ↳↳ [`SwampyerOperationError`](index.SwampyerOperationError.md)
+
+  ↳↳ [`TimeoutError`](index.TimeoutError.md)
+
+  ↳↳ [`AbortError`](index.AbortError.md)
+
+  ↳↳ [`ConnectionOpenError`](index.ConnectionOpenError.md)
+
+  ↳↳ [`TransportError`](index.TransportError.md)
+
+  ↳↳ [`TransportParseError`](index.TransportParseError.md)
+
+  ↳↳ [`ConnectionClosedError`](index.ConnectionClosedError.md)
+
+## Table of contents
+
+### Constructors
+
+- [constructor](index.SwampyerError.md#constructor)
+
+### Properties
+
+- [message](index.SwampyerError.md#message)
+- [name](index.SwampyerError.md#name)
+- [stack](index.SwampyerError.md#stack)
+- [prepareStackTrace](index.SwampyerError.md#preparestacktrace)
+- [stackTraceLimit](index.SwampyerError.md#stacktracelimit)
+
+### Methods
+
+- [captureStackTrace](index.SwampyerError.md#capturestacktrace)
+
+## Constructors
+
+### constructor
+
+• **new SwampyerError**(`message?`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message?` | `string` |
+
+#### Inherited from
+
+Error.constructor
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:979
+
+## Properties
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+Error.message
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:974
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+Error.name
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:973
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+Error.stack
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:975
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`see`** https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+Error.prepareStackTrace
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+Error.stackTraceLimit
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Error.captureStackTrace
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:4

--- a/docs/classes/index.SwampyerOperationError.md
+++ b/docs/classes/index.SwampyerOperationError.md
@@ -53,7 +53,7 @@
 
 #### Defined in
 
-[src/errors.ts:4](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/errors.ts#L4)
+[src/errors.ts:4](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/errors.ts#L4)
 
 ## Properties
 

--- a/docs/classes/index.SwampyerOperationError.md
+++ b/docs/classes/index.SwampyerOperationError.md
@@ -51,10 +51,6 @@
 
 [SwampyerError](index.SwampyerError.md).[constructor](index.SwampyerError.md#constructor)
 
-#### Defined in
-
-[src/errors.ts:4](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/errors.ts#L4)
-
 ## Properties
 
 ### args
@@ -83,10 +79,6 @@ ___
 
 [SwampyerError](index.SwampyerError.md).[message](index.SwampyerError.md#message)
 
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:974
-
 ___
 
 ### name
@@ -96,10 +88,6 @@ ___
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[name](index.SwampyerError.md#name)
-
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:973
 
 ___
 
@@ -116,10 +104,6 @@ ___
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[stack](index.SwampyerError.md#stack)
-
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:975
 
 ___
 
@@ -150,10 +134,6 @@ Optional override for formatting stack traces
 
 [SwampyerError](index.SwampyerError.md).[prepareStackTrace](index.SwampyerError.md#preparestacktrace)
 
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:11
-
 ___
 
 ### stackTraceLimit
@@ -163,10 +143,6 @@ ___
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[stackTraceLimit](index.SwampyerError.md#stacktracelimit)
-
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:13
 
 ## Methods
 
@@ -190,7 +166,3 @@ Create .stack property on a target object
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[captureStackTrace](index.SwampyerError.md#capturestacktrace)
-
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:4

--- a/docs/classes/index.SwampyerOperationError.md
+++ b/docs/classes/index.SwampyerOperationError.md
@@ -1,0 +1,196 @@
+[swampyer](../README.md) / [Modules](../modules.md) / [index](../modules/index.md) / SwampyerOperationError
+
+# Class: SwampyerOperationError
+
+[index](../modules/index.md).SwampyerOperationError
+
+## Hierarchy
+
+- [`SwampyerError`](index.SwampyerError.md)
+
+  ↳ **`SwampyerOperationError`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](index.SwampyerOperationError.md#constructor)
+
+### Properties
+
+- [args](index.SwampyerOperationError.md#args)
+- [details](index.SwampyerOperationError.md#details)
+- [kwargs](index.SwampyerOperationError.md#kwargs)
+- [message](index.SwampyerOperationError.md#message)
+- [name](index.SwampyerOperationError.md#name)
+- [reason](index.SwampyerOperationError.md#reason)
+- [stack](index.SwampyerOperationError.md#stack)
+- [prepareStackTrace](index.SwampyerOperationError.md#preparestacktrace)
+- [stackTraceLimit](index.SwampyerOperationError.md#stacktracelimit)
+
+### Methods
+
+- [captureStackTrace](index.SwampyerOperationError.md#capturestacktrace)
+
+## Constructors
+
+### constructor
+
+• **new SwampyerOperationError**(`details?`, `reason?`, `args?`, `kwargs?`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `details?` | `Object` |
+| `reason?` | `string` |
+| `args?` | `unknown`[] |
+| `kwargs?` | `Object` |
+
+#### Overrides
+
+[SwampyerError](index.SwampyerError.md).[constructor](index.SwampyerError.md#constructor)
+
+#### Defined in
+
+[src/errors.ts:4](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/errors.ts#L4)
+
+## Properties
+
+### args
+
+• `Optional` `Readonly` **args**: `unknown`[]
+
+___
+
+### details
+
+• `Optional` `Readonly` **details**: `Object`
+
+___
+
+### kwargs
+
+• `Optional` `Readonly` **kwargs**: `Object`
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[message](index.SwampyerError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:974
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[name](index.SwampyerError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:973
+
+___
+
+### reason
+
+• `Optional` `Readonly` **reason**: `string`
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[stack](index.SwampyerError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:975
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`see`** https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[prepareStackTrace](index.SwampyerError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[stackTraceLimit](index.SwampyerError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[captureStackTrace](index.SwampyerError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:4

--- a/docs/classes/index.TimeoutError.md
+++ b/docs/classes/index.TimeoutError.md
@@ -47,7 +47,7 @@
 
 #### Defined in
 
-[src/errors.ts:15](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/errors.ts#L15)
+[src/errors.ts:15](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/errors.ts#L15)
 
 ## Properties
 

--- a/docs/classes/index.TimeoutError.md
+++ b/docs/classes/index.TimeoutError.md
@@ -1,0 +1,172 @@
+[swampyer](../README.md) / [Modules](../modules.md) / [index](../modules/index.md) / TimeoutError
+
+# Class: TimeoutError
+
+[index](../modules/index.md).TimeoutError
+
+## Hierarchy
+
+- [`SwampyerError`](index.SwampyerError.md)
+
+  ↳ **`TimeoutError`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](index.TimeoutError.md#constructor)
+
+### Properties
+
+- [message](index.TimeoutError.md#message)
+- [name](index.TimeoutError.md#name)
+- [stack](index.TimeoutError.md#stack)
+- [timeout](index.TimeoutError.md#timeout)
+- [prepareStackTrace](index.TimeoutError.md#preparestacktrace)
+- [stackTraceLimit](index.TimeoutError.md#stacktracelimit)
+
+### Methods
+
+- [captureStackTrace](index.TimeoutError.md#capturestacktrace)
+
+## Constructors
+
+### constructor
+
+• **new TimeoutError**(`timeout`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `timeout` | `number` |
+
+#### Overrides
+
+[SwampyerError](index.SwampyerError.md).[constructor](index.SwampyerError.md#constructor)
+
+#### Defined in
+
+[src/errors.ts:15](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/errors.ts#L15)
+
+## Properties
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[message](index.SwampyerError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:974
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[name](index.SwampyerError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:973
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[stack](index.SwampyerError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:975
+
+___
+
+### timeout
+
+• `Readonly` **timeout**: `number`
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`see`** https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[prepareStackTrace](index.SwampyerError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[stackTraceLimit](index.SwampyerError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[captureStackTrace](index.SwampyerError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:4

--- a/docs/classes/index.TimeoutError.md
+++ b/docs/classes/index.TimeoutError.md
@@ -45,10 +45,6 @@
 
 [SwampyerError](index.SwampyerError.md).[constructor](index.SwampyerError.md#constructor)
 
-#### Defined in
-
-[src/errors.ts:15](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/errors.ts#L15)
-
 ## Properties
 
 ### message
@@ -58,10 +54,6 @@
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[message](index.SwampyerError.md#message)
-
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:974
 
 ___
 
@@ -73,10 +65,6 @@ ___
 
 [SwampyerError](index.SwampyerError.md).[name](index.SwampyerError.md#name)
 
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:973
-
 ___
 
 ### stack
@@ -86,10 +74,6 @@ ___
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[stack](index.SwampyerError.md#stack)
-
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:975
 
 ___
 
@@ -126,10 +110,6 @@ Optional override for formatting stack traces
 
 [SwampyerError](index.SwampyerError.md).[prepareStackTrace](index.SwampyerError.md#preparestacktrace)
 
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:11
-
 ___
 
 ### stackTraceLimit
@@ -139,10 +119,6 @@ ___
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[stackTraceLimit](index.SwampyerError.md#stacktracelimit)
-
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:13
 
 ## Methods
 
@@ -166,7 +142,3 @@ Create .stack property on a target object
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[captureStackTrace](index.SwampyerError.md#capturestacktrace)
-
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:4

--- a/docs/classes/index.TransportError.md
+++ b/docs/classes/index.TransportError.md
@@ -44,10 +44,6 @@
 
 [SwampyerError](index.SwampyerError.md).[constructor](index.SwampyerError.md#constructor)
 
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:979
-
 ## Properties
 
 ### message
@@ -57,10 +53,6 @@ node_modules/typescript/lib/lib.es5.d.ts:979
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[message](index.SwampyerError.md#message)
-
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:974
 
 ___
 
@@ -72,10 +64,6 @@ ___
 
 [SwampyerError](index.SwampyerError.md).[name](index.SwampyerError.md#name)
 
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:973
-
 ___
 
 ### stack
@@ -85,10 +73,6 @@ ___
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[stack](index.SwampyerError.md#stack)
-
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:975
 
 ___
 
@@ -119,10 +103,6 @@ Optional override for formatting stack traces
 
 [SwampyerError](index.SwampyerError.md).[prepareStackTrace](index.SwampyerError.md#preparestacktrace)
 
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:11
-
 ___
 
 ### stackTraceLimit
@@ -132,10 +112,6 @@ ___
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[stackTraceLimit](index.SwampyerError.md#stacktracelimit)
-
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:13
 
 ## Methods
 
@@ -159,7 +135,3 @@ Create .stack property on a target object
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[captureStackTrace](index.SwampyerError.md#capturestacktrace)
-
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:4

--- a/docs/classes/index.TransportError.md
+++ b/docs/classes/index.TransportError.md
@@ -1,0 +1,165 @@
+[swampyer](../README.md) / [Modules](../modules.md) / [index](../modules/index.md) / TransportError
+
+# Class: TransportError
+
+[index](../modules/index.md).TransportError
+
+## Hierarchy
+
+- [`SwampyerError`](index.SwampyerError.md)
+
+  ↳ **`TransportError`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](index.TransportError.md#constructor)
+
+### Properties
+
+- [message](index.TransportError.md#message)
+- [name](index.TransportError.md#name)
+- [stack](index.TransportError.md#stack)
+- [prepareStackTrace](index.TransportError.md#preparestacktrace)
+- [stackTraceLimit](index.TransportError.md#stacktracelimit)
+
+### Methods
+
+- [captureStackTrace](index.TransportError.md#capturestacktrace)
+
+## Constructors
+
+### constructor
+
+• **new TransportError**(`message?`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message?` | `string` |
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[constructor](index.SwampyerError.md#constructor)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:979
+
+## Properties
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[message](index.SwampyerError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:974
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[name](index.SwampyerError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:973
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[stack](index.SwampyerError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:975
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`see`** https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[prepareStackTrace](index.SwampyerError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[stackTraceLimit](index.SwampyerError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[captureStackTrace](index.SwampyerError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:4

--- a/docs/classes/index.TransportParseError.md
+++ b/docs/classes/index.TransportParseError.md
@@ -1,0 +1,165 @@
+[swampyer](../README.md) / [Modules](../modules.md) / [index](../modules/index.md) / TransportParseError
+
+# Class: TransportParseError
+
+[index](../modules/index.md).TransportParseError
+
+## Hierarchy
+
+- [`SwampyerError`](index.SwampyerError.md)
+
+  ↳ **`TransportParseError`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](index.TransportParseError.md#constructor)
+
+### Properties
+
+- [message](index.TransportParseError.md#message)
+- [name](index.TransportParseError.md#name)
+- [stack](index.TransportParseError.md#stack)
+- [prepareStackTrace](index.TransportParseError.md#preparestacktrace)
+- [stackTraceLimit](index.TransportParseError.md#stacktracelimit)
+
+### Methods
+
+- [captureStackTrace](index.TransportParseError.md#capturestacktrace)
+
+## Constructors
+
+### constructor
+
+• **new TransportParseError**(`message?`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message?` | `string` |
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[constructor](index.SwampyerError.md#constructor)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:979
+
+## Properties
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[message](index.SwampyerError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:974
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[name](index.SwampyerError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:973
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[stack](index.SwampyerError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:975
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`see`** https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[prepareStackTrace](index.SwampyerError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[stackTraceLimit](index.SwampyerError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[SwampyerError](index.SwampyerError.md).[captureStackTrace](index.SwampyerError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:4

--- a/docs/classes/index.TransportParseError.md
+++ b/docs/classes/index.TransportParseError.md
@@ -44,10 +44,6 @@
 
 [SwampyerError](index.SwampyerError.md).[constructor](index.SwampyerError.md#constructor)
 
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:979
-
 ## Properties
 
 ### message
@@ -57,10 +53,6 @@ node_modules/typescript/lib/lib.es5.d.ts:979
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[message](index.SwampyerError.md#message)
-
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:974
 
 ___
 
@@ -72,10 +64,6 @@ ___
 
 [SwampyerError](index.SwampyerError.md).[name](index.SwampyerError.md#name)
 
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:973
-
 ___
 
 ### stack
@@ -85,10 +73,6 @@ ___
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[stack](index.SwampyerError.md#stack)
-
-#### Defined in
-
-node_modules/typescript/lib/lib.es5.d.ts:975
 
 ___
 
@@ -119,10 +103,6 @@ Optional override for formatting stack traces
 
 [SwampyerError](index.SwampyerError.md).[prepareStackTrace](index.SwampyerError.md#preparestacktrace)
 
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:11
-
 ___
 
 ### stackTraceLimit
@@ -132,10 +112,6 @@ ___
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[stackTraceLimit](index.SwampyerError.md#stacktracelimit)
-
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:13
 
 ## Methods
 
@@ -159,7 +135,3 @@ Create .stack property on a target object
 #### Inherited from
 
 [SwampyerError](index.SwampyerError.md).[captureStackTrace](index.SwampyerError.md#capturestacktrace)
-
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:4

--- a/docs/classes/transports_transport.Transport.md
+++ b/docs/classes/transports_transport.Transport.md
@@ -48,7 +48,7 @@
 
 #### Defined in
 
-[src/transports/transport.ts:24](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L24)
+[src/transports/transport.ts:24](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L24)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[src/transports/transport.ts:22](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L22)
+[src/transports/transport.ts:22](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L22)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[src/transports/transport.ts:23](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L23)
+[src/transports/transport.ts:23](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L23)
 
 ## Accessors
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[src/transports/transport.ts:14](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L14)
+[src/transports/transport.ts:14](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L14)
 
 ## Methods
 
@@ -123,7 +123,7 @@ For use by the library
 
 #### Defined in
 
-[src/transports/transport.ts:63](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L63)
+[src/transports/transport.ts:63](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L63)
 
 ___
 
@@ -143,7 +143,7 @@ ___
 
 #### Defined in
 
-[src/transports/transport.ts:50](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L50)
+[src/transports/transport.ts:50](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L50)
 
 ___
 
@@ -157,7 +157,7 @@ ___
 
 #### Defined in
 
-[src/transports/transport.ts:46](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L46)
+[src/transports/transport.ts:46](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L46)
 
 ___
 
@@ -174,7 +174,7 @@ to read on this transport.
 
 #### Defined in
 
-[src/transports/transport.ts:30](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L30)
+[src/transports/transport.ts:30](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L30)
 
 ___
 
@@ -194,4 +194,4 @@ ___
 
 #### Defined in
 
-[src/transports/transport.ts:42](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L42)
+[src/transports/transport.ts:42](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L42)

--- a/docs/classes/transports_transport.Transport.md
+++ b/docs/classes/transports_transport.Transport.md
@@ -1,0 +1,197 @@
+[swampyer](../README.md) / [Modules](../modules.md) / [transports/transport](../modules/transports_transport.md) / Transport
+
+# Class: Transport
+
+[transports/transport](../modules/transports_transport.md).Transport
+
+## Table of contents
+
+### Constructors
+
+- [constructor](transports_transport.Transport.md#constructor)
+
+### Properties
+
+- [closeEvent](transports_transport.Transport.md#closeevent)
+- [messageEvent](transports_transport.Transport.md#messageevent)
+- [openEvent](transports_transport.Transport.md#openevent)
+
+### Accessors
+
+- [isClosed](transports_transport.Transport.md#isclosed)
+
+### Methods
+
+- [\_send](transports_transport.Transport.md#_send)
+- [close](transports_transport.Transport.md#close)
+- [open](transports_transport.Transport.md#open)
+- [read](transports_transport.Transport.md#read)
+- [write](transports_transport.Transport.md#write)
+
+## Constructors
+
+### constructor
+
+• **new Transport**()
+
+## Properties
+
+### closeEvent
+
+• `Readonly` **closeEvent**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `addEventListener` | (`callback`: (...`args`: [error?: Error]) => `void`) => () => `void` |
+
+#### Defined in
+
+[src/transports/transport.ts:24](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L24)
+
+___
+
+### messageEvent
+
+• `Readonly` **messageEvent**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `addEventListener` | (`callback`: (...`args`: [message: WampMessage]) => `void`) => () => `void` |
+
+#### Defined in
+
+[src/transports/transport.ts:22](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L22)
+
+___
+
+### openEvent
+
+• `Readonly` **openEvent**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `addEventListener` | (`callback`: (...`args`: []) => `void`) => () => `void` |
+
+#### Defined in
+
+[src/transports/transport.ts:23](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L23)
+
+## Accessors
+
+### isClosed
+
+• `get` **isClosed**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Defined in
+
+[src/transports/transport.ts:14](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L14)
+
+## Methods
+
+### \_send
+
+▸ **_send**<`T`\>(`messageType`, `data`): `void`
+
+For use by the library
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `MessageTypes` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `messageType` | `T` |
+| `data` | `MessageData`[`T`] |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[src/transports/transport.ts:63](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L63)
+
+___
+
+### close
+
+▸ **close**(`err?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err?` | `Error` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[src/transports/transport.ts:50](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L50)
+
+___
+
+### open
+
+▸ **open**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[src/transports/transport.ts:46](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L46)
+
+___
+
+### read
+
+▸ **read**(): `Promise`<`WampMessage`\>
+
+An exception indicates that the transport has been closed and there will be no more messages
+to read on this transport.
+
+#### Returns
+
+`Promise`<`WampMessage`\>
+
+#### Defined in
+
+[src/transports/transport.ts:30](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L30)
+
+___
+
+### write
+
+▸ **write**(`payload`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `payload` | `WampMessage` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[src/transports/transport.ts:42](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L42)

--- a/docs/classes/transports_transport.Transport.md
+++ b/docs/classes/transports_transport.Transport.md
@@ -46,10 +46,6 @@
 | :------ | :------ |
 | `addEventListener` | (`callback`: (...`args`: [error?: Error]) => `void`) => () => `void` |
 
-#### Defined in
-
-[src/transports/transport.ts:24](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L24)
-
 ___
 
 ### messageEvent
@@ -61,10 +57,6 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `addEventListener` | (`callback`: (...`args`: [message: WampMessage]) => `void`) => () => `void` |
-
-#### Defined in
-
-[src/transports/transport.ts:22](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L22)
 
 ___
 
@@ -78,10 +70,6 @@ ___
 | :------ | :------ |
 | `addEventListener` | (`callback`: (...`args`: []) => `void`) => () => `void` |
 
-#### Defined in
-
-[src/transports/transport.ts:23](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L23)
-
 ## Accessors
 
 ### isClosed
@@ -91,10 +79,6 @@ ___
 #### Returns
 
 `boolean`
-
-#### Defined in
-
-[src/transports/transport.ts:14](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L14)
 
 ## Methods
 
@@ -121,10 +105,6 @@ For use by the library
 
 `void`
 
-#### Defined in
-
-[src/transports/transport.ts:63](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L63)
-
 ___
 
 ### close
@@ -141,10 +121,6 @@ ___
 
 `void`
 
-#### Defined in
-
-[src/transports/transport.ts:50](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L50)
-
 ___
 
 ### open
@@ -154,10 +130,6 @@ ___
 #### Returns
 
 `void`
-
-#### Defined in
-
-[src/transports/transport.ts:46](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L46)
 
 ___
 
@@ -171,10 +143,6 @@ to read on this transport.
 #### Returns
 
 `Promise`<`WampMessage`\>
-
-#### Defined in
-
-[src/transports/transport.ts:30](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L30)
 
 ___
 
@@ -191,7 +159,3 @@ ___
 #### Returns
 
 `void`
-
-#### Defined in
-
-[src/transports/transport.ts:42](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L42)

--- a/docs/classes/transports_websocket_json.WebsocketJson.md
+++ b/docs/classes/transports_websocket_json.WebsocketJson.md
@@ -34,10 +34,6 @@
 | :------ | :------ |
 | `url` | `string` \| `URL` |
 
-#### Defined in
-
-[src/transports/websocket_json.ts:8](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/websocket_json.ts#L8)
-
 ## Properties
 
 ### transport
@@ -47,10 +43,6 @@
 #### Implementation of
 
 [TransportProvider](../interfaces/transports_transport.TransportProvider.md).[transport](../interfaces/transports_transport.TransportProvider.md#transport)
-
-#### Defined in
-
-[src/transports/websocket_json.ts:6](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/websocket_json.ts#L6)
 
 ## Methods
 
@@ -65,7 +57,3 @@
 #### Implementation of
 
 [TransportProvider](../interfaces/transports_transport.TransportProvider.md).[open](../interfaces/transports_transport.TransportProvider.md#open)
-
-#### Defined in
-
-[src/transports/websocket_json.ts:10](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/websocket_json.ts#L10)

--- a/docs/classes/transports_websocket_json.WebsocketJson.md
+++ b/docs/classes/transports_websocket_json.WebsocketJson.md
@@ -1,0 +1,71 @@
+[swampyer](../README.md) / [Modules](../modules.md) / [transports/websocket\_json](../modules/transports_websocket_json.md) / WebsocketJson
+
+# Class: WebsocketJson
+
+[transports/websocket_json](../modules/transports_websocket_json.md).WebsocketJson
+
+## Implements
+
+- [`TransportProvider`](../interfaces/transports_transport.TransportProvider.md)
+
+## Table of contents
+
+### Constructors
+
+- [constructor](transports_websocket_json.WebsocketJson.md#constructor)
+
+### Properties
+
+- [transport](transports_websocket_json.WebsocketJson.md#transport)
+
+### Methods
+
+- [open](transports_websocket_json.WebsocketJson.md#open)
+
+## Constructors
+
+### constructor
+
+• **new WebsocketJson**(`url`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `url` | `string` \| `URL` |
+
+#### Defined in
+
+[src/transports/websocket_json.ts:8](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/websocket_json.ts#L8)
+
+## Properties
+
+### transport
+
+• `Readonly` **transport**: [`Transport`](transports_transport.Transport.md)
+
+#### Implementation of
+
+[TransportProvider](../interfaces/transports_transport.TransportProvider.md).[transport](../interfaces/transports_transport.TransportProvider.md#transport)
+
+#### Defined in
+
+[src/transports/websocket_json.ts:6](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/websocket_json.ts#L6)
+
+## Methods
+
+### open
+
+▸ **open**(): `void`
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+[TransportProvider](../interfaces/transports_transport.TransportProvider.md).[open](../interfaces/transports_transport.TransportProvider.md#open)
+
+#### Defined in
+
+[src/transports/websocket_json.ts:10](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/websocket_json.ts#L10)

--- a/docs/classes/transports_websocket_json.WebsocketJson.md
+++ b/docs/classes/transports_websocket_json.WebsocketJson.md
@@ -36,7 +36,7 @@
 
 #### Defined in
 
-[src/transports/websocket_json.ts:8](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/websocket_json.ts#L8)
+[src/transports/websocket_json.ts:8](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/websocket_json.ts#L8)
 
 ## Properties
 
@@ -50,7 +50,7 @@
 
 #### Defined in
 
-[src/transports/websocket_json.ts:6](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/websocket_json.ts#L6)
+[src/transports/websocket_json.ts:6](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/websocket_json.ts#L6)
 
 ## Methods
 
@@ -68,4 +68,4 @@
 
 #### Defined in
 
-[src/transports/websocket_json.ts:10](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/websocket_json.ts#L10)
+[src/transports/websocket_json.ts:10](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/websocket_json.ts#L10)

--- a/docs/interfaces/index.CloseDetails.md
+++ b/docs/interfaces/index.CloseDetails.md
@@ -1,0 +1,43 @@
+[swampyer](../README.md) / [Modules](../modules.md) / [index](../modules/index.md) / CloseDetails
+
+# Interface: CloseDetails
+
+[index](../modules/index.md).CloseDetails
+
+## Table of contents
+
+### Properties
+
+- [error](index.CloseDetails.md#error)
+- [goodbye](index.CloseDetails.md#goodbye)
+
+## Properties
+
+### error
+
+• `Optional` **error**: [`SwampyerError`](../classes/index.SwampyerError.md)
+
+This value will only be defined if the connection was closed due to some error
+
+#### Defined in
+
+[src/types.ts:130](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L130)
+
+___
+
+### goodbye
+
+• `Optional` **goodbye**: `Object`
+
+This value will only be defined if the connection was closed due to a GOODBYE event
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `details` | `Object` |
+| `reason` | `string` |
+
+#### Defined in
+
+[src/types.ts:132](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L132)

--- a/docs/interfaces/index.CloseDetails.md
+++ b/docs/interfaces/index.CloseDetails.md
@@ -21,7 +21,7 @@ This value will only be defined if the connection was closed due to some error
 
 #### Defined in
 
-[src/types.ts:130](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L130)
+[src/types.ts:130](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L130)
 
 ___
 
@@ -40,4 +40,4 @@ This value will only be defined if the connection was closed due to a GOODBYE ev
 
 #### Defined in
 
-[src/types.ts:132](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L132)
+[src/types.ts:132](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L132)

--- a/docs/interfaces/index.CloseDetails.md
+++ b/docs/interfaces/index.CloseDetails.md
@@ -19,10 +19,6 @@
 
 This value will only be defined if the connection was closed due to some error
 
-#### Defined in
-
-[src/types.ts:130](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L130)
-
 ___
 
 ### goodbye
@@ -37,7 +33,3 @@ This value will only be defined if the connection was closed due to a GOODBYE ev
 | :------ | :------ |
 | `details` | `Object` |
 | `reason` | `string` |
-
-#### Defined in
-
-[src/types.ts:132](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L132)

--- a/docs/interfaces/index.OpenOptions.md
+++ b/docs/interfaces/index.OpenOptions.md
@@ -22,10 +22,6 @@
 An identifier for this client connection which may be used by the WAMP server for logging
 purposes
 
-#### Defined in
-
-[src/types.ts:82](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L82)
-
 ___
 
 ### auth
@@ -45,10 +41,6 @@ If this is not defined then the library will try to authenticate using the `anon
 | `authMethods` | `string`[] | Could be values like `anonymous`, `ticket`, `cookie`, etc.  Refer to your WAMP server's settings to find out which auth methods are supported. |
 | `onChallenge` | (`authMethod`: `string`) => `string` | - |
 
-#### Defined in
-
-[src/types.ts:104](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L104)
-
 ___
 
 ### realm
@@ -56,10 +48,6 @@ ___
 • **realm**: `string`
 
 The realm to connect to on the WAMP server
-
-#### Defined in
-
-[src/types.ts:77](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L77)
 
 ___
 
@@ -79,7 +67,3 @@ the `withoutUriBase` option for the operations that support that option
 
 **`example`** Setting this to `com.company.something` will allow you to shorten a `call()` to
 `com.company.something.my.fancy_registration` down to a `call()` to `my.fancy_registration`
-
-#### Defined in
-
-[src/types.ts:97](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L97)

--- a/docs/interfaces/index.OpenOptions.md
+++ b/docs/interfaces/index.OpenOptions.md
@@ -1,0 +1,85 @@
+[swampyer](../README.md) / [Modules](../modules.md) / [index](../modules/index.md) / OpenOptions
+
+# Interface: OpenOptions
+
+[index](../modules/index.md).OpenOptions
+
+## Table of contents
+
+### Properties
+
+- [agent](index.OpenOptions.md#agent)
+- [auth](index.OpenOptions.md#auth)
+- [realm](index.OpenOptions.md#realm)
+- [uriBase](index.OpenOptions.md#uribase)
+
+## Properties
+
+### agent
+
+• `Optional` **agent**: `string`
+
+An identifier for this client connection which may be used by the WAMP server for logging
+purposes
+
+#### Defined in
+
+[src/types.ts:82](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L82)
+
+___
+
+### auth
+
+• `Optional` **auth**: `Object`
+
+Optional authentication data
+
+If this is not defined then the library will try to authenticate using the `anonymous`
+`authMethod`. Omit this if you only need `anonymous` access.
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `authId` | `string` | The username or ID to authenticate as.  This value depends on the `authMethods` selected and the settings of your WAMP server. |
+| `authMethods` | `string`[] | Could be values like `anonymous`, `ticket`, `cookie`, etc.  Refer to your WAMP server's settings to find out which auth methods are supported. |
+| `onChallenge` | (`authMethod`: `string`) => `string` | - |
+
+#### Defined in
+
+[src/types.ts:104](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L104)
+
+___
+
+### realm
+
+• **realm**: `string`
+
+The realm to connect to on the WAMP server
+
+#### Defined in
+
+[src/types.ts:77](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L77)
+
+___
+
+### uriBase
+
+• `Optional` **uriBase**: `string`
+
+This string will be prepended to all of your URI cased WAMP operations. This can be a
+convenient way to shorten the WAMP URIs by defining the common part of the WAMP URIs
+here.
+
+The final URI that gets used for communicating with the WAMP server ends up being
+`{uriBase}.{URI of operation}`.
+
+It is also possible to disable the use of `uriBase` for a given WAMP operation by setting
+the `withoutUriBase` option for the operations that support that option
+
+**`example`** Setting this to `com.company.something` will allow you to shorten a `call()` to
+`com.company.something.my.fancy_registration` down to a `call()` to `my.fancy_registration`
+
+#### Defined in
+
+[src/types.ts:97](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L97)

--- a/docs/interfaces/index.OpenOptions.md
+++ b/docs/interfaces/index.OpenOptions.md
@@ -24,7 +24,7 @@ purposes
 
 #### Defined in
 
-[src/types.ts:82](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L82)
+[src/types.ts:82](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L82)
 
 ___
 
@@ -47,7 +47,7 @@ If this is not defined then the library will try to authenticate using the `anon
 
 #### Defined in
 
-[src/types.ts:104](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L104)
+[src/types.ts:104](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L104)
 
 ___
 
@@ -59,7 +59,7 @@ The realm to connect to on the WAMP server
 
 #### Defined in
 
-[src/types.ts:77](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L77)
+[src/types.ts:77](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L77)
 
 ___
 
@@ -82,4 +82,4 @@ the `withoutUriBase` option for the operations that support that option
 
 #### Defined in
 
-[src/types.ts:97](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L97)
+[src/types.ts:97](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L97)

--- a/docs/interfaces/index.PublishOptions.md
+++ b/docs/interfaces/index.PublishOptions.md
@@ -26,10 +26,6 @@
 Asks the WAMP server to acknowledge that the publish call has been fulfilled. `publish()`
 will wait for the acknowledgement from the WAMP server if this option is set to `true`.
 
-#### Defined in
-
-[src/types.ts:154](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L154)
-
 ___
 
 ### withoutUriBase
@@ -41,7 +37,3 @@ If true, the `uriBase` will not be prepended to the provided URI for this operat
 #### Inherited from
 
 CommonOptions.withoutUriBase
-
-#### Defined in
-
-[src/types.ts:140](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L140)

--- a/docs/interfaces/index.PublishOptions.md
+++ b/docs/interfaces/index.PublishOptions.md
@@ -28,7 +28,7 @@ will wait for the acknowledgement from the WAMP server if this option is set to 
 
 #### Defined in
 
-[src/types.ts:154](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L154)
+[src/types.ts:154](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L154)
 
 ___
 
@@ -44,4 +44,4 @@ CommonOptions.withoutUriBase
 
 #### Defined in
 
-[src/types.ts:140](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L140)
+[src/types.ts:140](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L140)

--- a/docs/interfaces/index.PublishOptions.md
+++ b/docs/interfaces/index.PublishOptions.md
@@ -1,0 +1,47 @@
+[swampyer](../README.md) / [Modules](../modules.md) / [index](../modules/index.md) / PublishOptions
+
+# Interface: PublishOptions
+
+[index](../modules/index.md).PublishOptions
+
+## Hierarchy
+
+- `CommonOptions`
+
+  ↳ **`PublishOptions`**
+
+## Table of contents
+
+### Properties
+
+- [acknowledge](index.PublishOptions.md#acknowledge)
+- [withoutUriBase](index.PublishOptions.md#withouturibase)
+
+## Properties
+
+### acknowledge
+
+• `Optional` **acknowledge**: `boolean`
+
+Asks the WAMP server to acknowledge that the publish call has been fulfilled. `publish()`
+will wait for the acknowledgement from the WAMP server if this option is set to `true`.
+
+#### Defined in
+
+[src/types.ts:154](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L154)
+
+___
+
+### withoutUriBase
+
+• `Optional` **withoutUriBase**: `boolean`
+
+If true, the `uriBase` will not be prepended to the provided URI for this operation
+
+#### Inherited from
+
+CommonOptions.withoutUriBase
+
+#### Defined in
+
+[src/types.ts:140](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L140)

--- a/docs/interfaces/transports_transport.TransportProvider.md
+++ b/docs/interfaces/transports_transport.TransportProvider.md
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-[src/transports/transport.ts:6](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L6)
+[src/transports/transport.ts:6](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L6)
 
 ## Methods
 
@@ -40,4 +40,4 @@
 
 #### Defined in
 
-[src/transports/transport.ts:5](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L5)
+[src/transports/transport.ts:5](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L5)

--- a/docs/interfaces/transports_transport.TransportProvider.md
+++ b/docs/interfaces/transports_transport.TransportProvider.md
@@ -24,10 +24,6 @@
 
 • **transport**: [`Transport`](../classes/transports_transport.Transport.md)
 
-#### Defined in
-
-[src/transports/transport.ts:6](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L6)
-
 ## Methods
 
 ### open
@@ -37,7 +33,3 @@
 #### Returns
 
 `void`
-
-#### Defined in
-
-[src/transports/transport.ts:5](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/transports/transport.ts#L5)

--- a/docs/interfaces/transports_transport.TransportProvider.md
+++ b/docs/interfaces/transports_transport.TransportProvider.md
@@ -1,0 +1,43 @@
+[swampyer](../README.md) / [Modules](../modules.md) / [transports/transport](../modules/transports_transport.md) / TransportProvider
+
+# Interface: TransportProvider
+
+[transports/transport](../modules/transports_transport.md).TransportProvider
+
+## Implemented by
+
+- [`WebsocketJson`](../classes/transports_websocket_json.WebsocketJson.md)
+
+## Table of contents
+
+### Properties
+
+- [transport](transports_transport.TransportProvider.md#transport)
+
+### Methods
+
+- [open](transports_transport.TransportProvider.md#open)
+
+## Properties
+
+### transport
+
+• **transport**: [`Transport`](../classes/transports_transport.Transport.md)
+
+#### Defined in
+
+[src/transports/transport.ts:6](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L6)
+
+## Methods
+
+### open
+
+▸ **open**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[src/transports/transport.ts:5](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/transports/transport.ts#L5)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,11 @@
+[swampyer](README.md) / Modules
+
+# swampyer
+
+## Table of contents
+
+### Modules
+
+- [index](modules/index.md)
+- [transports/transport](modules/transports_transport.md)
+- [transports/websocket\_json](modules/transports_websocket_json.md)

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -1,0 +1,147 @@
+[swampyer](../README.md) / [Modules](../modules.md) / index
+
+# Module: index
+
+## Table of contents
+
+### Classes
+
+- [AbortError](../classes/index.AbortError.md)
+- [ConnectionClosedError](../classes/index.ConnectionClosedError.md)
+- [ConnectionOpenError](../classes/index.ConnectionOpenError.md)
+- [Swampyer](../classes/index.Swampyer.md)
+- [SwampyerAutoReconnect](../classes/index.SwampyerAutoReconnect.md)
+- [SwampyerError](../classes/index.SwampyerError.md)
+- [SwampyerOperationError](../classes/index.SwampyerOperationError.md)
+- [TimeoutError](../classes/index.TimeoutError.md)
+- [TransportError](../classes/index.TransportError.md)
+- [TransportParseError](../classes/index.TransportParseError.md)
+
+### Interfaces
+
+- [CloseDetails](../interfaces/index.CloseDetails.md)
+- [OpenOptions](../interfaces/index.OpenOptions.md)
+- [PublishOptions](../interfaces/index.PublishOptions.md)
+
+### Type aliases
+
+- [CallOptions](index.md#calloptions)
+- [CloseReason](index.md#closereason)
+- [RegisterOptions](index.md#registeroptions)
+- [RegistrationHandler](index.md#registrationhandler)
+- [SubscribeOptions](index.md#subscribeoptions)
+- [SubscriptionHandler](index.md#subscriptionhandler)
+- [WelcomeDetails](index.md#welcomedetails)
+
+## Type aliases
+
+### CallOptions
+
+Ƭ **CallOptions**: `CommonOptions`
+
+#### Defined in
+
+[src/types.ts:146](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L146)
+
+___
+
+### CloseReason
+
+Ƭ **CloseReason**: ``"transport_error"`` \| ``"transport_close"`` \| ``"open_error"`` \| ``"goodbye"`` \| ``"close_method"``
+
+#### Defined in
+
+[src/types.ts:127](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L127)
+
+___
+
+### RegisterOptions
+
+Ƭ **RegisterOptions**: `CommonOptions`
+
+#### Defined in
+
+[src/types.ts:145](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L145)
+
+___
+
+### RegistrationHandler
+
+Ƭ **RegistrationHandler**: (`args`: `unknown`[], `kwargs`: `Object`, `details`: `Object`) => `void`
+
+#### Type declaration
+
+▸ (`args`, `kwargs`, `details`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `args` | `unknown`[] |
+| `kwargs` | `Object` |
+| `details` | `Object` |
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[src/types.ts:62](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L62)
+
+___
+
+### SubscribeOptions
+
+Ƭ **SubscribeOptions**: `CommonOptions`
+
+#### Defined in
+
+[src/types.ts:148](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L148)
+
+___
+
+### SubscriptionHandler
+
+Ƭ **SubscriptionHandler**: (`args`: `unknown`[], `kwargs`: `Object`, `details`: `Object`) => `void`
+
+#### Type declaration
+
+▸ (`args`, `kwargs`, `details`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `args` | `unknown`[] |
+| `kwargs` | `Object` |
+| `details` | `Object` |
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[src/types.ts:61](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L61)
+
+___
+
+### WelcomeDetails
+
+Ƭ **WelcomeDetails**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `authid` | `string` |
+| `authmethod` | `string` |
+| `authprovider?` | `string` |
+| `authrole` | `string` |
+| `realm?` | `string` |
+| `roles` | `Record`<`string`, `unknown`\> |
+
+#### Defined in
+
+[src/types.ts:64](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L64)

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -39,29 +39,17 @@
 
 Ƭ **CallOptions**: `CommonOptions`
 
-#### Defined in
-
-[src/types.ts:146](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L146)
-
 ___
 
 ### CloseReason
 
 Ƭ **CloseReason**: ``"transport_error"`` \| ``"transport_close"`` \| ``"open_error"`` \| ``"goodbye"`` \| ``"close_method"``
 
-#### Defined in
-
-[src/types.ts:127](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L127)
-
 ___
 
 ### RegisterOptions
 
 Ƭ **RegisterOptions**: `CommonOptions`
-
-#### Defined in
-
-[src/types.ts:145](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L145)
 
 ___
 
@@ -85,19 +73,11 @@ ___
 
 `void`
 
-#### Defined in
-
-[src/types.ts:62](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L62)
-
 ___
 
 ### SubscribeOptions
 
 Ƭ **SubscribeOptions**: `CommonOptions`
-
-#### Defined in
-
-[src/types.ts:148](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L148)
 
 ___
 
@@ -121,10 +101,6 @@ ___
 
 `void`
 
-#### Defined in
-
-[src/types.ts:61](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L61)
-
 ___
 
 ### WelcomeDetails
@@ -141,7 +117,3 @@ ___
 | `authrole` | `string` |
 | `realm?` | `string` |
 | `roles` | `Record`<`string`, `unknown`\> |
-
-#### Defined in
-
-[src/types.ts:64](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L64)

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[src/types.ts:146](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L146)
+[src/types.ts:146](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L146)
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 #### Defined in
 
-[src/types.ts:127](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L127)
+[src/types.ts:127](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L127)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[src/types.ts:145](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L145)
+[src/types.ts:145](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L145)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[src/types.ts:62](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L62)
+[src/types.ts:62](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L62)
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[src/types.ts:148](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L148)
+[src/types.ts:148](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L148)
 
 ___
 
@@ -123,7 +123,7 @@ ___
 
 #### Defined in
 
-[src/types.ts:61](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L61)
+[src/types.ts:61](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L61)
 
 ___
 
@@ -144,4 +144,4 @@ ___
 
 #### Defined in
 
-[src/types.ts:64](https://github.com/zaberSatnam/js-swampyer/blob/9cfd414/src/types.ts#L64)
+[src/types.ts:64](https://github.com/zaberSatnam/js-swampyer/blob/51c14e1/src/types.ts#L64)

--- a/docs/modules/transports_transport.md
+++ b/docs/modules/transports_transport.md
@@ -1,0 +1,13 @@
+[swampyer](../README.md) / [Modules](../modules.md) / transports/transport
+
+# Module: transports/transport
+
+## Table of contents
+
+### Classes
+
+- [Transport](../classes/transports_transport.Transport.md)
+
+### Interfaces
+
+- [TransportProvider](../interfaces/transports_transport.TransportProvider.md)

--- a/docs/modules/transports_websocket_json.md
+++ b/docs/modules/transports_websocket_json.md
@@ -1,0 +1,9 @@
+[swampyer](../README.md) / [Modules](../modules.md) / transports/websocket\_json
+
+# Module: transports/websocket\_json
+
+## Table of contents
+
+### Classes
+
+- [WebsocketJson](../classes/transports_websocket_json.WebsocketJson.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "swampyer-js",
-  "version": "0.1.0",
+  "name": "swampyer",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "swampyer-js",
-      "version": "0.1.0",
+      "name": "swampyer",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "eslint-plugin-import": "^2.25.2",
         "jest": "^27.2.5",
         "ts-jest": "^27.0.5",
+        "typedoc": "^0.22.10",
+        "typedoc-plugin-markdown": "^3.11.8",
         "typescript": "^4.4.3"
       }
     },
@@ -3029,6 +3031,27 @@
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
     },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -4295,6 +4318,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4362,6 +4391,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -4390,6 +4425,18 @@
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.x"
+      }
+    },
+    "node_modules/marked": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
+      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/merge-stream": {
@@ -4478,6 +4525,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "node_modules/node-int64": {
@@ -5016,6 +5069,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.15.tgz",
+      "integrity": "sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -5460,6 +5524,40 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.22.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
+      "integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.2.0",
+        "lunr": "^2.3.9",
+        "marked": "^3.0.8",
+        "minimatch": "^3.0.4",
+        "shiki": "^0.9.12"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 12.10.0"
+      },
+      "peerDependencies": {
+        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x"
+      }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "3.11.8",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.11.8.tgz",
+      "integrity": "sha512-j2Kwi/RnwDwiNr9CMy4lrwB9+1alwjrMakb9+7S0Bz9gnDsdqamOguZ6e27iB97U18nK6GBeR8qDarIyoJYDCg==",
+      "dev": true,
+      "dependencies": {
+        "handlebars": "^4.7.7"
+      },
+      "peerDependencies": {
+        "typedoc": ">=0.22.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
@@ -5471,6 +5569,19 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.5.tgz",
+      "integrity": "sha512-qZukoSxOG0urUTvjc2ERMTcAy+BiFh3weWAkeurLwjrCba73poHmG3E36XEjd/JGukMzwTL7uCxZiAexj8ppvQ==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -5534,6 +5645,18 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz",
+      "integrity": "sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -5642,6 +5765,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -8053,6 +8182,19 @@
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
     },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -8998,6 +9140,12 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -9050,6 +9198,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -9073,6 +9227,12 @@
       "requires": {
         "tmpl": "1.0.x"
       }
+    },
+    "marked": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
+      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
+      "dev": true
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -9142,6 +9302,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "node-int64": {
@@ -9518,6 +9684,17 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shiki": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.15.tgz",
+      "integrity": "sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -9846,11 +10023,40 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.22.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
+      "integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.2.0",
+        "lunr": "^2.3.9",
+        "marked": "^3.0.8",
+        "minimatch": "^3.0.4",
+        "shiki": "^0.9.12"
+      }
+    },
+    "typedoc-plugin-markdown": {
+      "version": "3.11.8",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.11.8.tgz",
+      "integrity": "sha512-j2Kwi/RnwDwiNr9CMy4lrwB9+1alwjrMakb9+7S0Bz9gnDsdqamOguZ6e27iB97U18nK6GBeR8qDarIyoJYDCg==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.7.7"
+      }
+    },
     "typescript": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
       "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true
+    },
+    "uglify-js": {
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.5.tgz",
+      "integrity": "sha512-qZukoSxOG0urUTvjc2ERMTcAy+BiFh3weWAkeurLwjrCba73poHmG3E36XEjd/JGukMzwTL7uCxZiAexj8ppvQ==",
+      "dev": true,
+      "optional": true
     },
     "unbox-primitive": {
       "version": "1.0.1",
@@ -9903,6 +10109,18 @@
           "dev": true
         }
       }
+    },
+    "vscode-oniguruma": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz",
+      "integrity": "sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -9989,6 +10207,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "test": "jest",
-    "lint": "eslint --config .eslintrc.js \"src/**/*.{js,ts}\""
+    "lint": "eslint --config .eslintrc.js \"src/**/*.{js,ts}\"",
+    "gen-docs": "typedoc --out docs --excludePrivate src src/transports/transport.ts src/transports/websocket_json.ts"
   },
   "author": "Zaber Technologies Inc.",
   "license": "MIT",
@@ -22,6 +23,8 @@
     "eslint-plugin-import": "^2.25.2",
     "jest": "^27.2.5",
     "ts-jest": "^27.0.5",
+    "typedoc": "^0.22.10",
+    "typedoc-plugin-markdown": "^3.11.8",
     "typescript": "^4.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build": "tsc --project tsconfig.build.json",
     "test": "jest",
     "lint": "eslint --config .eslintrc.js \"src/**/*.{js,ts}\"",
-    "gen-docs": "typedoc --out docs --excludePrivate src src/transports/transport.ts src/transports/websocket_json.ts"
+    "gen-docs": "typedoc --out docs --excludePrivate --disableSources src src/transports/transport.ts src/transports/websocket_json.ts"
   },
   "devDependencies": {
     "@types/jest": "^27.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swampyer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A lightweight WAMP client implementing the WAMP v2 basic profile",
   "main": "lib/index.js",
   "module": "lib/index.js",
@@ -8,14 +8,28 @@
   "files": [
     "lib"
   ],
+  "author": "Zaber Technologies Inc.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zaberTech/js-swampyer"
+  },
+  "bugs": {
+    "url": "https://github.com/zaberTech/js-swampyer/issues"
+  },
+  "homepage": "https://github.com/zaberTech/js-swampyer",
+  "keywords": [
+    "websocket",
+    "wamp",
+    "pubsub",
+    "rpc"
+  ],
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "test": "jest",
     "lint": "eslint --config .eslintrc.js \"src/**/*.{js,ts}\"",
     "gen-docs": "typedoc --out docs --excludePrivate src src/transports/transport.ts src/transports/websocket_json.ts"
   },
-  "author": "Zaber Technologies Inc.",
-  "license": "MIT",
   "devDependencies": {
     "@types/jest": "^27.0.2",
     "@typescript-eslint/eslint-plugin": "^5.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { Swampyer } from './swampyer';
+export { SwampyerAutoReconnect } from './swampyer_auto_reconnect';
 export type { OpenOptions, PublishOptions, WelcomeDetails } from './types';
 export * from './errors';
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
 export { Swampyer } from './swampyer';
 export { SwampyerAutoReconnect } from './swampyer_auto_reconnect';
-export type { OpenOptions, PublishOptions, WelcomeDetails } from './types';
+export type {
+  OpenOptions,
+  RegisterOptions, CallOptions, SubscribeOptions, PublishOptions,
+  WelcomeDetails,
+  CloseReason, CloseDetails,
+  SubscriptionHandler, RegistrationHandler
+} from './types';
 export * from './errors';

--- a/src/swampyer.ts
+++ b/src/swampyer.ts
@@ -78,7 +78,7 @@ export class Swampyer {
               const authData = options.auth.onChallenge(authMethod);
               this.transport!._send(MessageTypes.Authenticate, [authData, {}]);
             } catch (e) {
-              const details = { message: 'An exception occured in onChallenge handler' };
+              const details = { message: `An exception occured in onChallenge handler: ${String(e)}` };
               this.transport!._send(MessageTypes.Abort, [details, errorReason]);
               deferred.reject(new AbortError(errorReason, details));
             }

--- a/src/swampyer.ts
+++ b/src/swampyer.ts
@@ -2,12 +2,7 @@ import { AbortError, ConnectionOpenError, ConnectionClosedError, SwampyerError, 
 import type { Transport, TransportProvider } from './transports/transport';
 import {
   WampMessage, MessageData, MessageTypes, PublishOptions, RegistrationHandler, SubscriptionHandler, WelcomeDetails,
-  OpenOptions,
-  RegisterOptions,
-  CallOptions,
-  SubscribeOptions,
-  CloseReason,
-  CloseDetails
+  OpenOptions, RegisterOptions, CallOptions, SubscribeOptions, CloseReason, CloseDetails
 } from './types';
 import { generateRandomInt, deferredPromise, SimpleEventEmitter } from './utils';
 

--- a/src/swampyer.ts
+++ b/src/swampyer.ts
@@ -103,7 +103,7 @@ export class Swampyer {
         this._openEvent.emit(details);
       })
       .catch(error => {
-        this.resetState(error);
+        this.resetState(error, true);
       })
       .finally(() => {
         openListenerCleanup();
@@ -259,8 +259,8 @@ export class Swampyer {
     }
   }
 
-  private resetState(error?: Error) {
-    if (this.isOpen) {
+  private resetState(error?: Error, wasOpening?: boolean) {
+    if (this.isOpen || wasOpening) {
       this._closeEvent.emit(error);
     }
 

--- a/src/swampyer_auto_reconnect.test.ts
+++ b/src/swampyer_auto_reconnect.test.ts
@@ -1,6 +1,7 @@
 import { SwampyerAutoReconnect } from './swampyer_auto_reconnect';
 import { Transport, TransportProvider } from './transports/transport';
 import { MessageData, MessageTypes, OpenOptions } from './types';
+import { waitUntilPass } from './utils';
 
 class MockTransportProvider implements TransportProvider {
   transport = new Transport();
@@ -21,8 +22,8 @@ const openOptions: OpenOptions = {
 let transportProvider: MockTransportProvider;
 let wamp: SwampyerAutoReconnect;
 
-async function doSuccessfulWampConnection() {
-  expect(await transportProvider.transport.read()).toEqual([MessageTypes.Hello, 'test-realm', expect.any(Object)]);
+async function acceptWampConnection() {
+  await transportProvider.transport.read();
   transportProvider.sendToLib(MessageTypes.Welcome, [1234, {
     authid: 'someone',
     authrole: 'auth_master',
@@ -31,16 +32,24 @@ async function doSuccessfulWampConnection() {
   }]);
 }
 
+async function rejectWampConnection() {
+  await transportProvider.transport.read();
+  transportProvider.sendToLib(MessageTypes.Abort, ['some.error.happened', 'no reason at all']);
+}
+
 afterEach(() => {
   transportProvider = null!;
   wamp = null!;
+  jest.useRealTimers();
 });
 
 it(`opens a WAMP connection when ${SwampyerAutoReconnect.prototype.attemptOpen.name}() is used`, async () => {
-  wamp = new SwampyerAutoReconnect(openOptions, () => (transportProvider = new MockTransportProvider(), transportProvider));
+  const transportProviderFunc = jest.fn(() => (transportProvider = new MockTransportProvider(), transportProvider));
+  wamp = new SwampyerAutoReconnect(openOptions, transportProviderFunc);
   wamp.attemptOpen();
-  await doSuccessfulWampConnection();
+  await acceptWampConnection();
   expect(wamp.isOpen).toBe(true);
+  expect(transportProviderFunc).toBeCalledTimes(1);
 });
 
 it(`throws an error if ${SwampyerAutoReconnect.prototype.open.name}() is used`, async () => {
@@ -48,9 +57,48 @@ it(`throws an error if ${SwampyerAutoReconnect.prototype.open.name}() is used`, 
   expect(() => wamp.open(transportProvider, openOptions)).toThrow(Error);
 });
 
-it('attempts reconnections when the WAMP connection closes for some reason', async () => {});
-it('attempts reconnections when the WAMP connection can not be opened', async () => {});
+it('attempts reconnections when the WAMP connection can not be opened', async () => {
+  jest.useFakeTimers();
+  const onClose = jest.fn();
+  const transportProviderFunc = jest.fn(() => (transportProvider = new MockTransportProvider(), transportProvider));
+
+  wamp = new SwampyerAutoReconnect(openOptions, transportProviderFunc);
+  wamp.closeEvent.addEventListener(onClose);
+
+  wamp.attemptOpen();
+  await rejectWampConnection();
+
+  await waitUntilPass(() => expect(onClose).toBeCalledTimes(1))
+
+  expect(transportProviderFunc).toBeCalledTimes(1);
+  jest.advanceTimersByTime(2);
+  await waitUntilPass(() => expect(transportProviderFunc).toBeCalledTimes(2));
+
+  await acceptWampConnection();
+  expect(wamp.isOpen).toBe(true);
+});
+
+it('attempts reconnections when the WAMP connection closes for some reason', async () => {
+  jest.useFakeTimers();
+  const transportProviderFunc = jest.fn(() => (transportProvider = new MockTransportProvider(), transportProvider));
+
+  wamp = new SwampyerAutoReconnect(openOptions, transportProviderFunc);
+  wamp.attemptOpen();
+  await acceptWampConnection();
+  expect(wamp.isOpen).toBe(true);
+  expect(transportProviderFunc).toBeCalledTimes(1);
+
+  transportProvider.transport.close();
+  expect(wamp.isOpen).toBe(false);
+
+  jest.advanceTimersByTime(2);
+  expect(transportProviderFunc).toBeCalledTimes(2);
+  await acceptWampConnection();
+  expect(wamp.isOpen).toBe(true);
+});
+
 it('gets a new transport provider for each reconnection attempt', async () => {});
 it('stops trying to reconnect if the function to get the transport provider returns "null"', async () => {});
 it('optionally gets the delay for each reconnection attempt from the user defined function', async () => {});
 it('stops trying to reconnect if the function to get delay returns "null"', async () => {});
+it(`does not try to reconnect if ${SwampyerAutoReconnect.prototype.close.name}() is called`, async () => {});

--- a/src/swampyer_auto_reconnect.test.ts
+++ b/src/swampyer_auto_reconnect.test.ts
@@ -1,0 +1,56 @@
+import { SwampyerAutoReconnect } from './swampyer_auto_reconnect';
+import { Transport, TransportProvider } from './transports/transport';
+import { MessageData, MessageTypes, OpenOptions } from './types';
+
+class MockTransportProvider implements TransportProvider {
+  transport = new Transport();
+  isOpen = false;
+  open() {
+    this.transport.open();
+    this.isOpen = true;
+  }
+  sendToLib<T extends MessageTypes>(messageType: T, data: MessageData[T]) {
+    this.transport.write([messageType, ...data]);
+  }
+}
+
+const openOptions: OpenOptions = {
+  realm: 'test-realm',
+}
+
+let transportProvider: MockTransportProvider;
+let wamp: SwampyerAutoReconnect;
+
+async function doSuccessfulWampConnection() {
+  expect(await transportProvider.transport.read()).toEqual([MessageTypes.Hello, 'test-realm', expect.any(Object)]);
+  transportProvider.sendToLib(MessageTypes.Welcome, [1234, {
+    authid: 'someone',
+    authrole: 'auth_master',
+    authmethod: 'anonymous',
+    roles: {}
+  }]);
+}
+
+afterEach(() => {
+  transportProvider = null!;
+  wamp = null!;
+});
+
+it(`opens a WAMP connection when ${SwampyerAutoReconnect.prototype.attemptOpen.name}() is used`, async () => {
+  wamp = new SwampyerAutoReconnect(openOptions, () => (transportProvider = new MockTransportProvider(), transportProvider));
+  wamp.attemptOpen();
+  await doSuccessfulWampConnection();
+  expect(wamp.isOpen).toBe(true);
+});
+
+it(`throws an error if ${SwampyerAutoReconnect.prototype.open.name}() is used`, async () => {
+  wamp = new SwampyerAutoReconnect(openOptions, () => (transportProvider = new MockTransportProvider(), transportProvider));
+  expect(() => wamp.open(transportProvider, openOptions)).toThrow(Error);
+});
+
+it('attempts reconnections when the WAMP connection closes for some reason', async () => {});
+it('attempts reconnections when the WAMP connection can not be opened', async () => {});
+it('gets a new transport provider for each reconnection attempt', async () => {});
+it('stops trying to reconnect if the function to get the transport provider returns "null"', async () => {});
+it('optionally gets the delay for each reconnection attempt from the user defined function', async () => {});
+it('stops trying to reconnect if the function to get delay returns "null"', async () => {});

--- a/src/swampyer_auto_reconnect.test.ts
+++ b/src/swampyer_auto_reconnect.test.ts
@@ -17,7 +17,7 @@ class MockTransportProvider implements TransportProvider {
 
 const openOptions: OpenOptions = {
   realm: 'test-realm',
-}
+};
 
 let transportProvider: MockTransportProvider;
 let wamp: SwampyerAutoReconnect;
@@ -68,7 +68,7 @@ it('attempts reconnections when the WAMP connection can not be opened', async ()
   wamp.attemptOpen();
   await rejectWampConnection();
 
-  await waitUntilPass(() => expect(onClose).toBeCalledTimes(1))
+  await waitUntilPass(() => expect(onClose).toBeCalledTimes(1));
 
   expect(transportProviderFunc).toBeCalledTimes(1);
   jest.advanceTimersByTime(2);
@@ -100,7 +100,7 @@ it('attempts reconnections when the WAMP connection closes for some reason', asy
 it('optionally gets the delay for each reconnection attempt from the user defined function', async () => {
   jest.useFakeTimers();
   const transportProviderFunc = jest.fn(() => (transportProvider = new MockTransportProvider(), transportProvider));
-  const delayFunc = jest.fn(attempt => 77);
+  const delayFunc = jest.fn(() => 77);
   const onClose = jest.fn();
 
   wamp = new SwampyerAutoReconnect(openOptions, transportProviderFunc, delayFunc);
@@ -131,8 +131,8 @@ it('optionally gets the delay for each reconnection attempt from the user define
 
 it('does not attempt reconnection if the function to get the transport provider returns "null"', async () => {
   jest.useFakeTimers();
-  const transportProviderFunc = jest.fn(() => null)
-  const delayFunc = jest.fn(attempt => 1);
+  const transportProviderFunc = jest.fn(() => null);
+  const delayFunc = jest.fn(() => 1);
 
   wamp = new SwampyerAutoReconnect(openOptions, transportProviderFunc, delayFunc);
   wamp.attemptOpen();
@@ -179,10 +179,10 @@ it(`does not attempt reconnection if ${SwampyerAutoReconnect.prototype.close.nam
   wamp.attemptOpen();
   await acceptWampConnection();
 
-  wamp.close();
+  const closePromise = wamp.close();
   await transportProvider.transport.read();
   transportProvider.sendToLib(MessageTypes.Goodbye, [{}, 'com.fine.go.away.then']);
-  await waitUntilPass(() => expect(onClose).toBeCalledTimes(1));
+  await closePromise;
 
   jest.advanceTimersByTime(100);
 

--- a/src/swampyer_auto_reconnect.ts
+++ b/src/swampyer_auto_reconnect.ts
@@ -1,0 +1,61 @@
+import { Swampyer } from './swampyer';
+import { TransportProvider } from './transports/transport';
+import { CloseDetails, CloseReason, OpenOptions, WelcomeDetails } from './types';
+
+type CloseEventData = [closeReason: CloseReason, closeDetails: CloseDetails];
+
+export const DEFAULT_RECONNECTION_DELAYS = [1, 10, 100, 1000, 2000, 4000, 8000, 16000, 32000];
+function defaultGetReconnectionDelay(attempt: number) {
+  return DEFAULT_RECONNECTION_DELAYS[Math.min(attempt, DEFAULT_RECONNECTION_DELAYS.length - 1)];
+}
+
+export class SwampyerAutoReconnect extends Swampyer {
+  private attempt = 0;
+
+  constructor(
+    private options: OpenOptions,
+    private getTransportProvider: (attempt: number, ...closeData: Partial<CloseEventData>) => TransportProvider | null,
+    getReconnectionDelay: (attempt: number, ...closeData: CloseEventData) => number | null = defaultGetReconnectionDelay
+  ) {
+    super();
+
+    this.closeEvent.addEventListener((reason, details) => {
+      if (reason === 'close_method') {
+        return;
+      }
+
+      const delay = getReconnectionDelay(this.attempt, reason, details);
+      if (delay == null) {
+        return;
+      }
+
+      setTimeout(() => this._attemptOpen(reason, details), delay);
+      this.attempt ++;
+    });
+
+    this.openEvent.addEventListener(() => {
+      this.attempt = 0;
+    });
+  }
+
+  /** This function is not supported on this class. Please use {@link attemptOpen} instead. */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  open(...args: Parameters<InstanceType<typeof Swampyer>['open']>): Promise<WelcomeDetails> {
+    throw new Error(`${this.open.name}() is not supported on ${SwampyerAutoReconnect.name}. Use ${this.attemptOpen.name}() instead.`);
+  }
+
+  /**
+   * Starts the process of openinig the WAMP connection. It will handle auto reconnection if the
+   * open operation fails or if the connection closes at any point.
+   */
+  attemptOpen() {
+    this._attemptOpen();
+  }
+
+  private _attemptOpen(...[closeReason, closeDetails]: Partial<CloseEventData>) {
+    const transportProvider = this.getTransportProvider(this.attempt, closeReason, closeDetails);
+    if (transportProvider != null) {
+      void super.open(transportProvider, this.options).catch(() => { /* Not used */ });
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,12 +127,12 @@ export interface OpenOptions {
 export type CloseReason = 'transport_error' | 'transport_close' | 'open_error' | 'goodbye' | 'close_method';
 export interface CloseDetails {
   /** This value will only be defined if the connection was closed due to some error */
-  error?: SwampyerError,
+  error?: SwampyerError;
   /** This value will only be defined if the connection was closed due to a GOODBYE event */
   goodbye?: {
-    reason: string,
-    details: any
-  }
+    reason: string;
+    details: Object;
+  };
 }
 
 interface CommonOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { SwampyerError } from './errors';
+
 export enum MessageTypes {
   Hello = 1,
   Welcome = 2,
@@ -120,6 +122,17 @@ export interface OpenOptions {
      */
     onChallenge: (authMethod: string) => string;
   };
+}
+
+export type CloseReason = 'transport_error' | 'transport_close' | 'open_error' | 'goodbye' | 'close_method';
+export interface CloseDetails {
+  /** This value will only be defined if the connection was closed due to some error */
+  error?: SwampyerError,
+  /** This value will only be defined if the connection was closed due to a GOODBYE event */
+  goodbye?: {
+    reason: string,
+    details: any
+  }
 }
 
 interface CommonOptions {


### PR DESCRIPTION
- Add new `SwampyerAutoReconnect` class that can automatically handle reconnections in case the WAMP connection is lost
- The `closeEvent` event emitter now emits an event when the `open()` operation fails
  - This is useful for implementing a cleaner auto reconnection mechanism
- Update README
- Update `package.json` so that it has more info in it relevant to the `npm` registry
- Added automatically generated documentation