### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,31 @@
+# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run lint
+    - run: npm test
+    - run: npm run build

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,46 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Publish NPM package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test
+      - run: npm run build
+      - name: Cache build
+        uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./lib
+          key: ${{ github.sha }}
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - name: Restore build cache
+        uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./lib
+          key: ${{ github.sha }}
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/docs/classes/index.Swampyer.md
+++ b/docs/classes/index.Swampyer.md
@@ -90,18 +90,22 @@ ___
 
 ▸ **call**(`uri`, `args?`, `kwargs?`, `options?`): `Promise`<`unknown`\>
 
+Call a WAMP URI and get its result
+
 #### Parameters
 
-| Name | Type | Default value |
-| :------ | :------ | :------ |
-| `uri` | `string` | `undefined` |
-| `args` | `unknown`[] | `[]` |
-| `kwargs` | `Object` | `{}` |
-| `options` | `CommonOptions` | `{}` |
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `uri` | `string` | `undefined` | The WAMP URI to call  If the `uriBase` options was defined when opening the connection then `uriBase` will be prepended to the provided URI (unless the appropriate value is set in `options`) |
+| `args` | `unknown`[] | `[]` | Positional arguments |
+| `kwargs` | `Object` | `{}` | Keyword arguments |
+| `options` | [`CommonOptions`](../interfaces/index.CommonOptions.md) | `{}` | Settings for how the registration should be done. This may vary between WAMP servers |
 
 #### Returns
 
 `Promise`<`unknown`\>
+
+Arbitrary data returned by the call operation
 
 ___
 
@@ -109,12 +113,14 @@ ___
 
 ▸ **close**(`reason?`, `message?`): `Promise`<`void`\>
 
+Close the WAMP connection
+
 #### Parameters
 
-| Name | Type | Default value |
-| :------ | :------ | :------ |
-| `reason` | `string` | `'wamp.close.system_shutdown'` |
-| `message?` | `string` | `undefined` |
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `reason` | `string` | `'wamp.close.system_shutdown'` | The reason for the closure |
+| `message?` | `string` | `undefined` | Some descriptive message about why the connection is being closed |
 
 #### Returns
 
@@ -156,7 +162,7 @@ Open a WAMP connection that will automatically reconnect in case of failure or c
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `getTransportProvider` | (`attempt`: `number`, ...`closeData`: [reason: CloseReason, details: CloseDetails]) => [`TransportProvider`](../interfaces/transports_transport.TransportProvider.md) | A function that should return a fresh TransportProvider for each reconnection attempt |
+| `getTransportProvider` | (`attempt`: `number`, ...`closeData`: [reason: CloseReason, details: CloseDetails]) => [`TransportProvider`](../interfaces/transports_transport.TransportProvider.md) | A function that should return a fresh TransportProvider for each reconnection attempt.  The `attempt` argument for this callback will be `0` for the initial connection attempt. For all reconnection attempts, the `attempt` value will start from `1`. |
 | `options` | [`OpenOptions`](../interfaces/index.OpenOptions.md) | The options for configuring the WAMP connection |
 
 #### Returns
@@ -169,14 +175,16 @@ ___
 
 ▸ **publish**(`uri`, `args?`, `kwargs?`, `options?`): `Promise`<`void`\>
 
+Publish an event on the given WAMP URI
+
 #### Parameters
 
-| Name | Type | Default value |
-| :------ | :------ | :------ |
-| `uri` | `string` | `undefined` |
-| `args` | `unknown`[] | `[]` |
-| `kwargs` | `Object` | `{}` |
-| `options` | [`PublishOptions`](../interfaces/index.PublishOptions.md) | `{}` |
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `uri` | `string` | `undefined` | The WAMP URI to publish the event for  If the `uriBase` options was defined when opening the connection then `uriBase` will be prepended to the provided URI (unless the appropriate value is set in `options`) |
+| `args` | `unknown`[] | `[]` | Positional arguments |
+| `kwargs` | `Object` | `{}` | Keyword arguments |
+| `options` | [`PublishOptions`](../interfaces/index.PublishOptions.md) | `{}` | Settings for how the registration should be done. This may vary between WAMP servers |
 
 #### Returns
 
@@ -188,17 +196,21 @@ ___
 
 ▸ **register**(`uri`, `handler`, `options?`): `Promise`<`number`\>
 
+Register a callback for a WAMP URI
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `uri` | `string` |
-| `handler` | [`RegistrationHandler`](../modules/index.md#registrationhandler) |
-| `options` | `CommonOptions` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `uri` | `string` | The URI to register for.  If the `uriBase` options was defined when opening the connection then `uriBase` will be prepended to the provided URI (unless the appropriate value is set in `options`) |
+| `handler` | [`RegistrationHandler`](../modules/index.md#registrationhandler) | The callback function that will handle invocations for this uri |
+| `options` | [`CommonOptions`](../interfaces/index.CommonOptions.md) | Settings for how the registration should be done. This may vary across WAMP servers |
 
 #### Returns
 
 `Promise`<`number`\>
+
+The registration ID (useful for unregistering)
 
 ___
 
@@ -206,17 +218,21 @@ ___
 
 ▸ **subscribe**(`uri`, `handler`, `options?`): `Promise`<`number`\>
 
+Subscribe to publish events on a given WAMP URI
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `uri` | `string` |
-| `handler` | [`SubscriptionHandler`](../modules/index.md#subscriptionhandler) |
-| `options` | `CommonOptions` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `uri` | `string` | The URI to subscribe to  If the `uriBase` options was defined when opening the connection then `uriBase` will be prepended to the provided URI (unless the appropriate value is set in `options`) |
+| `handler` | [`SubscriptionHandler`](../modules/index.md#subscriptionhandler) | The callback function that will handle subscription events for this uri |
+| `options` | [`CommonOptions`](../interfaces/index.CommonOptions.md) | Settings for how the subscription should be done. This may vary across WAMP servers |
 
 #### Returns
 
 `Promise`<`number`\>
+
+The subscription ID (useful for unsubscribing)
 
 ___
 
@@ -224,11 +240,13 @@ ___
 
 ▸ **unregister**(`registrationId`): `Promise`<`void`\>
 
+Unregister an existing registration
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `registrationId` | `number` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `registrationId` | `number` | The registration ID returned by [register()](index.Swampyer.md#register) |
 
 #### Returns
 
@@ -239,6 +257,8 @@ ___
 ### unsubscribe
 
 ▸ **unsubscribe**(`subscriptionId`): `Promise`<`void`\>
+
+Unsubscribe from an existing subscription
 
 #### Parameters
 

--- a/docs/classes/transports_transport.Transport.md
+++ b/docs/classes/transports_transport.Transport.md
@@ -89,7 +89,7 @@ ___
 
 ▸ **_send**<`T`\>(`messageType`, `data`): `void`
 
-For use by the library
+For use internally within the library
 
 #### Type parameters
 

--- a/docs/interfaces/index.CommonOptions.md
+++ b/docs/interfaces/index.CommonOptions.md
@@ -1,0 +1,29 @@
+[swampyer](../README.md) / [Modules](../modules.md) / [index](../modules/index.md) / CommonOptions
+
+# Interface: CommonOptions
+
+[index](../modules/index.md).CommonOptions
+
+## Hierarchy
+
+- **`CommonOptions`**
+
+  ↳ [`PublishOptions`](index.PublishOptions.md)
+
+## Indexable
+
+▪ [key: `string`]: `any`
+
+## Table of contents
+
+### Properties
+
+- [withoutUriBase](index.CommonOptions.md#withouturibase)
+
+## Properties
+
+### withoutUriBase
+
+• `Optional` **withoutUriBase**: `boolean`
+
+If true, the `uriBase` will not be prepended to the provided URI for this operation

--- a/docs/interfaces/index.OpenOptions.md
+++ b/docs/interfaces/index.OpenOptions.md
@@ -84,6 +84,8 @@ any number <= 0 then the library will no longer try to reconnect.
 If this function is not defined then the library will use a delay that increases with
 each successive reconnection attempt (up to a maximum of 32000ms)
 
+The `attempt` argument for the function will always be `>= 1`.
+
 #### Parameters
 
 | Name | Type |

--- a/docs/interfaces/index.PublishOptions.md
+++ b/docs/interfaces/index.PublishOptions.md
@@ -6,7 +6,7 @@
 
 ## Hierarchy
 
-- `CommonOptions`
+- [`CommonOptions`](index.CommonOptions.md)
 
   ↳ **`PublishOptions`**
 
@@ -36,4 +36,4 @@ If true, the `uriBase` will not be prepended to the provided URI for this operat
 
 #### Inherited from
 
-CommonOptions.withoutUriBase
+[CommonOptions](index.CommonOptions.md).[withoutUriBase](index.CommonOptions.md#withouturibase)

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -19,6 +19,7 @@
 ### Interfaces
 
 - [CloseDetails](../interfaces/index.CloseDetails.md)
+- [CommonOptions](../interfaces/index.CommonOptions.md)
 - [OpenOptions](../interfaces/index.OpenOptions.md)
 - [PublishOptions](../interfaces/index.PublishOptions.md)
 
@@ -36,7 +37,7 @@
 
 ### CallOptions
 
-Ƭ **CallOptions**: `CommonOptions`
+Ƭ **CallOptions**: [`CommonOptions`](../interfaces/index.CommonOptions.md)
 
 ___
 
@@ -48,7 +49,7 @@ ___
 
 ### RegisterOptions
 
-Ƭ **RegisterOptions**: `CommonOptions`
+Ƭ **RegisterOptions**: [`CommonOptions`](../interfaces/index.CommonOptions.md)
 
 ___
 
@@ -76,7 +77,7 @@ ___
 
 ### SubscribeOptions
 
-Ƭ **SubscribeOptions**: `CommonOptions`
+Ƭ **SubscribeOptions**: [`CommonOptions`](../interfaces/index.CommonOptions.md)
 
 ___
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@types/jest": "^27.0.2",
         "@typescript-eslint/eslint-plugin": "^5.2.0",
+        "@typescript-eslint/parser": "^5.8.0",
         "eslint": "^8.1.0",
         "eslint-plugin-import": "^2.25.2",
         "jest": "^27.2.5",
@@ -1232,15 +1233,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.2.0.tgz",
-      "integrity": "sha512-Uyy4TjJBlh3NuA8/4yIQptyJb95Qz5PX//6p8n7zG0QnN4o3NF9Je3JHbVU7fxf5ncSXTmnvMtd/LDQWDk0YqA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.8.0.tgz",
+      "integrity": "sha512-Gleacp/ZhRtJRYs5/T8KQR3pAQjQI89Dn/k+OzyCKOsLiZH2/Vh60cFBTnFsHNI6WAD+lNUo/xGZ4NeA5u0Ipw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.2.0",
-        "@typescript-eslint/types": "5.2.0",
-        "@typescript-eslint/typescript-estree": "5.2.0",
+        "@typescript-eslint/scope-manager": "5.8.0",
+        "@typescript-eslint/types": "5.8.0",
+        "@typescript-eslint/typescript-estree": "5.8.0",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -1257,6 +1257,95 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.8.0.tgz",
+      "integrity": "sha512-x82CYJsLOjPCDuFFEbS6e7K1QEWj7u5Wk1alw8A+gnJiYwNnDJk0ib6PCegbaPMjrfBvFKa7SxE3EOnnIQz2Gg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.8.0",
+        "@typescript-eslint/visitor-keys": "5.8.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.8.0.tgz",
+      "integrity": "sha512-LdCYOqeqZWqCMOmwFnum6YfW9F3nKuxJiR84CdIRN5nfHJ7gyvGpXWqL/AaW0k3Po0+wm93ARAsOdzlZDPCcXg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.8.0.tgz",
+      "integrity": "sha512-srfeZ3URdEcUsSLbkOFqS7WoxOqn8JNil2NSLO9O+I2/Uyc85+UlfpEvQHIpj5dVts7KKOZnftoJD/Fdv0L7nQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.8.0",
+        "@typescript-eslint/visitor-keys": "5.8.0",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.8.0.tgz",
+      "integrity": "sha512-+HDIGOEMnqbxdAHegxvnOqESUH6RWFRR2b8qxP1W9CZnnYh4Usz6MBL+2KMAgPk/P0o9c1HqnYtwzVH6GTIqug==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.8.0",
+        "eslint-visitor-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -6834,16 +6923,67 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.2.0.tgz",
-      "integrity": "sha512-Uyy4TjJBlh3NuA8/4yIQptyJb95Qz5PX//6p8n7zG0QnN4o3NF9Je3JHbVU7fxf5ncSXTmnvMtd/LDQWDk0YqA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.8.0.tgz",
+      "integrity": "sha512-Gleacp/ZhRtJRYs5/T8KQR3pAQjQI89Dn/k+OzyCKOsLiZH2/Vh60cFBTnFsHNI6WAD+lNUo/xGZ4NeA5u0Ipw==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.2.0",
-        "@typescript-eslint/types": "5.2.0",
-        "@typescript-eslint/typescript-estree": "5.2.0",
+        "@typescript-eslint/scope-manager": "5.8.0",
+        "@typescript-eslint/types": "5.8.0",
+        "@typescript-eslint/typescript-estree": "5.8.0",
         "debug": "^4.3.2"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.8.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.8.0.tgz",
+          "integrity": "sha512-x82CYJsLOjPCDuFFEbS6e7K1QEWj7u5Wk1alw8A+gnJiYwNnDJk0ib6PCegbaPMjrfBvFKa7SxE3EOnnIQz2Gg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.8.0",
+            "@typescript-eslint/visitor-keys": "5.8.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.8.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.8.0.tgz",
+          "integrity": "sha512-LdCYOqeqZWqCMOmwFnum6YfW9F3nKuxJiR84CdIRN5nfHJ7gyvGpXWqL/AaW0k3Po0+wm93ARAsOdzlZDPCcXg==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.8.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.8.0.tgz",
+          "integrity": "sha512-srfeZ3URdEcUsSLbkOFqS7WoxOqn8JNil2NSLO9O+I2/Uyc85+UlfpEvQHIpj5dVts7KKOZnftoJD/Fdv0L7nQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.8.0",
+            "@typescript-eslint/visitor-keys": "5.8.0",
+            "debug": "^4.3.2",
+            "globby": "^11.0.4",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.8.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.8.0.tgz",
+          "integrity": "sha512-+HDIGOEMnqbxdAHegxvnOqESUH6RWFRR2b8qxP1W9CZnnYh4Usz6MBL+2KMAgPk/P0o9c1HqnYtwzVH6GTIqug==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.8.0",
+            "eslint-visitor-keys": "^3.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/scope-manager": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swampyer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "swampyer",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swampyer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A lightweight WAMP client implementing the WAMP v2 basic profile",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@types/jest": "^27.0.2",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
+    "@typescript-eslint/parser": "^5.8.0",
     "eslint": "^8.1.0",
     "eslint-plugin-import": "^2.25.2",
     "jest": "^27.2.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export { Swampyer } from './swampyer';
 export type {
   OpenOptions,
-  RegisterOptions, CallOptions, SubscribeOptions, PublishOptions,
+  RegisterOptions, CallOptions, SubscribeOptions, PublishOptions, CommonOptions,
   WelcomeDetails,
   CloseReason, CloseDetails,
   SubscriptionHandler, RegistrationHandler

--- a/src/swampyer.ts
+++ b/src/swampyer.ts
@@ -48,7 +48,7 @@ export class Swampyer {
    *
    * @param getTransportProvider A function that should return a fresh TransportProvider for each
    * reconnection attempt.
-   * 
+   *
    * The `attempt` argument for this callback will be `0` for the initial connection attempt.
    * For all reconnection attempts, the `attempt` value will start from `1`.
    * @param options The options for configuring the WAMP connection
@@ -192,6 +192,12 @@ export class Swampyer {
     return deferred.promise;
   }
 
+  /**
+   * Close the WAMP connection
+   *
+   * @param reason The reason for the closure
+   * @param message Some descriptive message about why the connection is being closed
+   */
   async close(reason = 'wamp.close.system_shutdown', message?: string): Promise<void> {
     if (this._isReconnecting) {
       this._closeMethodCallEvent.emit();
@@ -219,6 +225,17 @@ export class Swampyer {
     return deferred.promise;
   }
 
+  /**
+   * Register a callback for a WAMP URI
+   *
+   * @param uri The URI to register for.
+   *
+   * If the `uriBase` options was defined when opening the connection then `uriBase` will be
+   * prepended to the provided URI (unless the appropriate value is set in `options`)
+   * @param handler The callback function that will handle invocations for this uri
+   * @param options Settings for how the registration should be done. This may vary across WAMP servers
+   * @returns The registration ID (useful for unregistering)
+   */
   async register(uri: string, handler: RegistrationHandler, options: RegisterOptions = {}): Promise<number> {
     this.throwIfNotOpen();
     const fullUri = options.withoutUriBase ? uri : this.getFullUri(uri);
@@ -229,6 +246,11 @@ export class Swampyer {
     return registrationId;
   }
 
+  /**
+   * Unregister an existing registration
+   *
+   * @param registrationId The registration ID returned by {@link register register()}
+   */
   async unregister(registrationId: number): Promise<void> {
     this.throwIfNotOpen();
     const requestId = this.unregistrationRequestId;
@@ -237,6 +259,18 @@ export class Swampyer {
     delete this.registrationHandlers[registrationId];
   }
 
+  /**
+   * Call a WAMP URI and get its result
+   *
+   * @param uri The WAMP URI to call
+   *
+   * If the `uriBase` options was defined when opening the connection then `uriBase` will be
+   * prepended to the provided URI (unless the appropriate value is set in `options`)
+   * @param args Positional arguments
+   * @param kwargs Keyword arguments
+   * @param options Settings for how the registration should be done. This may vary between WAMP servers
+   * @returns Arbitrary data returned by the call operation
+   */
   async call(uri: string, args: unknown[] = [], kwargs: Object = {}, options: CallOptions = {}): Promise<unknown> {
     this.throwIfNotOpen();
     const fullUri = options.withoutUriBase ? uri : this.getFullUri(uri);
@@ -246,6 +280,17 @@ export class Swampyer {
     return resultArray[0];
   }
 
+  /**
+   * Subscribe to publish events on a given WAMP URI
+   *
+   * @param uri The URI to subscribe to
+   *
+   * If the `uriBase` options was defined when opening the connection then `uriBase` will be
+   * prepended to the provided URI (unless the appropriate value is set in `options`)
+   * @param handler The callback function that will handle subscription events for this uri
+   * @param options Settings for how the subscription should be done. This may vary across WAMP servers
+   * @returns The subscription ID (useful for unsubscribing)
+   */
   async subscribe(uri: string, handler: SubscriptionHandler, options: SubscribeOptions = {}): Promise<number> {
     this.throwIfNotOpen();
     const fullUri = options.withoutUriBase ? uri : this.getFullUri(uri);
@@ -255,6 +300,11 @@ export class Swampyer {
     return subscriptionId;
   }
 
+  /**
+   * Unsubscribe from an existing subscription
+   *
+   * @param registrationId The subscription ID returned by {@link subscribe subscribe()}
+   */
   async unsubscribe(subscriptionId: number): Promise<void> {
     this.throwIfNotOpen();
     const requestId = generateRandomInt();
@@ -262,6 +312,17 @@ export class Swampyer {
     delete this.subscriptionHandlers[subscriptionId];
   }
 
+  /**
+   * Publish an event on the given WAMP URI
+   *
+   * @param uri The WAMP URI to publish the event for
+   *
+   * If the `uriBase` options was defined when opening the connection then `uriBase` will be
+   * prepended to the provided URI (unless the appropriate value is set in `options`)
+   * @param args Positional arguments
+   * @param kwargs Keyword arguments
+   * @param options Settings for how the registration should be done. This may vary between WAMP servers
+   */
   async publish(uri: string, args: unknown[] = [], kwargs: Object = {}, options: PublishOptions = {}): Promise<void> {
     this.throwIfNotOpen();
     const fullUri = options.withoutUriBase ? uri : this.getFullUri(uri);

--- a/src/transports/transport.ts
+++ b/src/transports/transport.ts
@@ -58,7 +58,7 @@ export class Transport {
   }
 
   /**
-   * For use by the library
+   * For use internally within the library
    */
   _send<T extends MessageTypes>(messageType: T, data: MessageData[T]) {
     const message: WampMessage = [messageType, ...data];

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,7 +146,7 @@ export interface CloseDetails {
 }
 export type CloseEventData = [reason: CloseReason, details: CloseDetails];
 
-interface CommonOptions {
+export interface CommonOptions {
   /** If true, the `uriBase` will not be prepended to the provided URI for this operation */
   withoutUriBase?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,6 +128,8 @@ export interface OpenOptions {
    *
    * If this function is not defined then the library will use a delay that increases with
    * each successive reconnection attempt (up to a maximum of 32000ms)
+   * 
+   * The `attempt` argument for the function will always be `>= 1`.
    */
   autoReconnectionDelay?: (attempt: number, ...closeData: CloseEventData) => number | null;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,7 +128,7 @@ export interface OpenOptions {
    *
    * If this function is not defined then the library will use a delay that increases with
    * each successive reconnection attempt (up to a maximum of 32000ms)
-   * 
+   *
    * The `attempt` argument for the function will always be `>= 1`.
    */
   autoReconnectionDelay?: (attempt: number, ...closeData: CloseEventData) => number | null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,6 +22,11 @@ export class SimpleEventEmitter<Data extends unknown[] = []> {
   private callbacks: Record<number, (...args: Data) => void> = {};
 
   public readonly publicObject = {
+    /** Add a callback function that will be called whenever a new event is emitted
+     * 
+     * **Note**: Any exceptions that occur in the callback will not be propagated. So please make
+     * sure exceptions are handled properly within the callback function itself
+     */
     addEventListener: this.addEventListener.bind(this),
     waitForNext: this.waitForNext.bind(this),
   };
@@ -45,9 +50,11 @@ export class SimpleEventEmitter<Data extends unknown[] = []> {
   }
 
   emit(...data: Data) {
-    void Promise.resolve(
-      Object.values(this.callbacks).forEach(callback => callback(...data))
-    );
+    Object.values(this.callbacks).forEach(callback => {
+      try {
+        callback(...data);
+      } catch(e) { /* Do nothing */ }
+    });
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,7 +23,7 @@ export class SimpleEventEmitter<Data extends unknown[] = []> {
 
   public readonly publicObject = {
     /** Add a callback function that will be called whenever a new event is emitted
-     * 
+     *
      * **Note**: Any exceptions that occur in the callback will not be propagated. So please make
      * sure exceptions are handled properly within the callback function itself
      */
@@ -53,7 +53,7 @@ export class SimpleEventEmitter<Data extends unknown[] = []> {
     Object.values(this.callbacks).forEach(callback => {
       try {
         callback(...data);
-      } catch(e) { /* Do nothing */ }
+      } catch (e) { /* Do nothing */ }
     });
   }
 }


### PR DESCRIPTION
- We now have github action workflows to help maintain code quality and simplify the package publishing process
  - Normal push to `master` runs tests, linting, and build
  - Pull requests to `master` runs tests, linting, and build
  - Making a new release runs tests, linting and builds the code and then publishes it to npm
- Fixed an issue with `Swampyer::openAutoReconnect()` where the `attempt` argument for the callbacks was not being updated properly
  - Now, on the initial connection attempt, the `attempt` value is `0`. All subsequent reconnection attempts will only start at `1`. When the connection opens successfully, the `attempt` value is reset back to `1`
- Errors in the event listener callbacks in `SimpleEventListener` no longer propagate
  - Unfortunately, these errors will essentially get lost in the void. I couldn't come up with a clean way to somehow tell the user that there is an exception in their event listener callback. The user will just have to be responsible for doing their own exception handling in the callback
- Added jsdoc to all the public methods of `Swampyer` wherever appropriate