### PR TITLE
Add `stopAutoReconnection` to options for `openAutoReconnection()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ npm i swampyer
     () => new WebsocketJson('ws://localhost:8080/ws')
     {
       realm: 'realm1',
-      autoReconnectionDelay: (attempt) => attempt < 4 ? 1000 : null;
+      autoReconnectionDelay: () => 1000,
+      stopAutoReconnection: (attempt) => attempt >= 4,
     }
   );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swampyer",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A lightweight WAMP client implementing the WAMP v2 basic profile",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/swampyer.test.ts
+++ b/src/swampyer.test.ts
@@ -314,31 +314,31 @@ describe(`${Swampyer.prototype.openAutoReconnect.name}()`, () => {
     await waitUntilPass(() => expect(wamp.isReconnecting).toBe(false));
   });
 
-  it('does not attempt reconnection if the function to get delay returns "null"', async () => {
+  it('does not attempt reconnection if the function to stop auto reconnections returns true', async () => {
     jest.useFakeTimers();
     const transportProviderFunc = jest.fn(() => getNewTransportProvider());
-    const delayFunc = jest.fn(() => null);
+    const stopAutoReconnection = jest.fn(() => true);
     const onClose = jest.fn();
 
     wamp = new Swampyer();
     wamp.closeEvent.addEventListener(onClose);
-    wamp.openAutoReconnect(transportProviderFunc, { ...openOptions, autoReconnectionDelay: delayFunc });
+    wamp.openAutoReconnect(transportProviderFunc, { ...openOptions, stopAutoReconnection });
 
     expect(transportProviderFunc).toBeCalledTimes(1);
-    expect(delayFunc).toBeCalledTimes(0);
+    expect(stopAutoReconnection).toBeCalledTimes(0);
 
     await rejectWampConnection();
     await waitUntilPass(() => expect(onClose).toBeCalledTimes(1));
 
     expect(transportProviderFunc).toBeCalledTimes(1);
-    await waitUntilPass(() => expect(delayFunc).toBeCalledTimes(1));
+    await waitUntilPass(() => expect(stopAutoReconnection).toBeCalledTimes(1));
 
     expect(wamp.isReconnecting).toBe(false);
     jest.advanceTimersByTime(100);
     expect(wamp.isReconnecting).toBe(false);
 
     expect(transportProviderFunc).toBeCalledTimes(1);
-    expect(delayFunc).toBeCalledTimes(1);
+    expect(stopAutoReconnection).toBeCalledTimes(1);
   });
 
   it(`does not attempt reconnection if ${Swampyer.prototype.close.name}() is called`, async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,16 +122,26 @@ export interface OpenOptions {
      */
     onChallenge: (authMethod: string) => string;
   };
+}
+
+export interface AutoReconnectionOpenOptions extends OpenOptions {
   /**
-   * Define a custom delay between reconnection attempts. If this function returns `null` or
-   * any number <= 0 then the library will no longer try to reconnect.
+   * Define a custom delay between reconnection attempts.
    *
    * If this function is not defined then the library will use a delay that increases with
    * each successive reconnection attempt (up to a maximum of 32000ms)
    *
    * The `attempt` argument for the function will always be `>= 1`.
    */
-  autoReconnectionDelay?: (attempt: number, ...closeData: CloseEventData) => number | null;
+  autoReconnectionDelay?: (attempt: number, ...closeData: CloseEventData) => number;
+  /**
+   * Control whether or not if the library should attempt an auto reconnection or not. Return
+   * `true` to stop any further auto reconnection attempts.
+   * 
+   * If this function is not defined then the library will keep trying to reconnect if
+   * connections are lost at any point.
+   */
+  stopAutoReconnection?: (attempt: number, ...closeData: CloseEventData) => boolean;
 }
 
 export type CloseReason = 'transport_error' | 'transport_close' | 'open_error' | 'goodbye' | 'close_method';

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,7 +137,7 @@ export interface AutoReconnectionOpenOptions extends OpenOptions {
   /**
    * Control whether or not if the library should attempt an auto reconnection or not. Return
    * `true` to stop any further auto reconnection attempts.
-   * 
+   *
    * If this function is not defined then the library will keep trying to reconnect if
    * connections are lost at any point.
    */


### PR DESCRIPTION
- It is a lot clearer way to stop automatic reconnections compared to the previous way of doing it
  - Previously we had to set the `autoReconnectionDelay` option and return `null` from it in order to stop automatic reconnections
  - But this meant that the developer also had to worry about returning valid delay values for cases where they did not want to stop automatic reconnection
- Updated tests
- Updated README
- Bumped version to `1.3.0`