### PR TITLE
rm9901 - allow for async onchallenge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swampyer",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "swampyer",
-      "version": "1.2.1",
+      "version": "1.3.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swampyer",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A lightweight WAMP client implementing the WAMP v2 basic profile",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/swampyer.ts
+++ b/src/swampyer.ts
@@ -157,16 +157,16 @@ export class Swampyer {
           const [authMethod] = data as MessageData[MessageTypes.Challenge];
           const errorReason = 'wamp.error.cannot_authenticate';
           if (options.auth?.onChallenge) {
-            try {
-              const authData = options.auth.onChallenge(authMethod);
-              this.transport!._send(MessageTypes.Authenticate, [authData, {}]);
-            } catch (e) {
-              const details = { message: `An exception occured in onChallenge handler: ${String(e)}` };
-              this.transport!._send(MessageTypes.Abort, [details, errorReason]);
-              deferred.reject(new AbortError(errorReason, details));
-            }
+            Promise.resolve()
+              .then(() => options.auth!.onChallenge(authMethod))
+              .then(authData => this.transport!._send(MessageTypes.Authenticate, [authData, {}]))
+              .catch(e => {
+                const details = { message: `An exception occured in onChallenge handler: ${String(e)}` };
+                this.transport!._send(MessageTypes.Abort, [details, errorReason]);
+                deferred.reject(new AbortError(errorReason, details));
+              });
           } else {
-            const details = { message: 'An onChallenge handler is not defined' };
+            const details = { message: 'A onChallenge handler is not defined' };
             this.transport!._send(MessageTypes.Abort, [details, errorReason]);
             deferred.reject(new AbortError(errorReason, details));
           }

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,7 +120,7 @@ export interface OpenOptions {
      * Depending on the auth method requested by the server, this could return things like the
      * password of the user we are trying to authenticate as.
      */
-    onChallenge: (authMethod: string) => string;
+    onChallenge: (authMethod: string) => string | Promise<string>;
   };
 }
 


### PR DESCRIPTION
- The `auth.onChallenge` option for all the `open*` methods can now be either synchronous (as before) or asynchronous (the new functionality in this PR)
- I have added a new test to explicitly test that swampyer can handle async `auth.onChallenge` option