### PR TITLE
9901 - better errors

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,10 @@
-export class SwampyerError extends Error {}
+export class SwampyerError {
+  constructor(public readonly message?: string) {}
+
+  toString() {
+    return this.message;
+  }
+}
 
 export class SwampyerOperationError extends SwampyerError {
   constructor(
@@ -8,6 +14,10 @@ export class SwampyerOperationError extends SwampyerError {
     public readonly kwargs?: Object
   ) {
     super(reason);
+  }
+
+  toString() {
+    return `${this.message}\n\n${this.args?.join('\n\n')}`;
   }
 }
 


### PR DESCRIPTION
- Turns out that if an error class extends `Error` then those errors get displayed in a formatted way in the browser console
  - The formatting includes the stack trace and just shows the `message` part of the error
  - There is no way to see whatever else might be present in the error object
  - In the case of swampyer errors, we do want to be able to see the object and see more details
- So, now we no longer extend `Error` for any of the Swampyer errors
- I have also added a `toString()` implementation so that `String(error)` works nicely
  - Implemented it differently on `SwampyerOperationError` because some times the `args` contain important information about the error that is not captured in the `reason` value (which is what we return by default)
- The tests have also been updated to account for these changes