### PR TITLE
10270 - Simplify serialization of registration handler errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swampyer",
-  "version": "1.3.1",
+  "version": "1.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "swampyer",
-      "version": "1.3.1",
+      "version": "1.4.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swampyer",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A lightweight WAMP client implementing the WAMP v2 basic profile",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/swampyer.test.ts
+++ b/src/swampyer.test.ts
@@ -53,7 +53,7 @@ let transportProvider: MockTransportProvider;
 let wamp: Swampyer;
 
 const mockConsole = new MockConsole();
-const realConsole = console;
+// eslint-disable-next-line no-global-assign
 console = mockConsole.console;
 
 beforeEach(() => {
@@ -831,7 +831,9 @@ describe(`${Swampyer.prototype.subscribe.name}()`, () => {
     transportProvider.sendToLib(MessageTypes.Event, [1234, 5555, {}, ['args'], {}]);
     expect(subHandler).toBeCalledTimes(1);
 
+    // eslint-disable-next-line no-console
     expect(console.error).toBeCalledTimes(1);
+    // eslint-disable-next-line no-console
     expect(console.error).toBeCalledWith(expect.any(String), expect.any(Error));
   });
 });

--- a/src/swampyer.test.ts
+++ b/src/swampyer.test.ts
@@ -563,36 +563,14 @@ describe(`${Swampyer.prototype.register.name}()`, () => {
       expect(await transportProvider.transport.read()).toEqual([MessageTypes.Yield, 5656, {}, ['fancy result'], {}]);
     });
 
-    describe('handles errors thrown by registration callbacks and returns the error to the caller', () => {
-      it('handles thrown Error object', async () => {
-        const errorObj = new Error('Some error');
-        const regHandler = jest.fn().mockImplementation(async () => { throw errorObj });
-        await testErrorHandling(
-          regHandler,
-          [String(errorObj)],
-          { errorDetails: {} }
-        );
-      });
-
-      it('handles thrown string', async () => {
-        const errorObj = 'Some error';
-        const regHandler = jest.fn().mockImplementation(async () => { throw errorObj });
-        await testErrorHandling(
-          regHandler,
-          [String(errorObj)],
-          { errorDetails: errorObj }
-        );
-      });
-
-      it('handles arbitrary thrown object', async () => {
-        const errorObj = { a: 1, b: 2, c: { d: 3, e: 4 }, f: [5, 6, { g: 7 }, [8, 9]] };
-        const regHandler = jest.fn().mockImplementation(async () => { throw errorObj });
-        await testErrorHandling(
-          regHandler,
-          [String(errorObj)],
-          { errorDetails: expect.objectContaining(errorObj) }
-        );
-      });
+    it('handles errors thrown by registration callbacks and returns the error to the caller as best as it can', async () => {
+      const errorObj = new Error('Some error');
+      const regHandler = jest.fn().mockImplementation(async () => { throw errorObj });
+      await testErrorHandling(
+        regHandler,
+        [String(errorObj)],
+        { errorDetails: errorObj }
+      );
     });
   });
 
@@ -619,36 +597,14 @@ describe(`${Swampyer.prototype.register.name}()`, () => {
       expect(await transportProvider.transport.read()).toEqual([MessageTypes.Yield, 5656, {}, ['fancy result'], {}]);
     });
 
-    describe('handles errors thrown by registration callbacks and returns the error to the caller', () => {
-      it('handles thrown Error object', async () => {
-        const errorObj = new Error('Some error');
-        const regHandler = jest.fn().mockImplementation(() => { throw errorObj });
-        await testErrorHandling(
-          regHandler,
-          [String(errorObj)],
-          { errorDetails: {} }
-        );
-      });
-
-      it('handles thrown string', async () => {
-        const errorObj = 'Some error';
-        const regHandler = jest.fn().mockImplementation(() => { throw errorObj });
-        await testErrorHandling(
-          regHandler,
-          [String(errorObj)],
-          { errorDetails: errorObj }
-        );
-      });
-
-      it('handles arbitrary thrown object', async () => {
-        const errorObj = { a: 1, b: 2, c: { d: 3, e: 4 }, f: [5, 6, { g: 7 }, [8, 9]] };
-        const regHandler = jest.fn().mockImplementation(() => { throw errorObj });
-        await testErrorHandling(
-          regHandler,
-          [String(errorObj)],
-          { errorDetails: expect.objectContaining(errorObj) }
-        );
-      });
+    it('handles errors thrown by registration callbacks and returns the error to the caller as best as it can', async () => {
+      const errorObj = new Error('Some error');
+      const regHandler = jest.fn().mockImplementation(() => { throw errorObj });
+      await testErrorHandling(
+        regHandler,
+        [String(errorObj)],
+        { errorDetails: errorObj }
+      );
     });
   });
 

--- a/src/swampyer.test.ts
+++ b/src/swampyer.test.ts
@@ -570,12 +570,7 @@ describe(`${Swampyer.prototype.register.name}()`, () => {
         await testErrorHandling(
           regHandler,
           [String(errorObj)],
-          {
-            errorDetails: expect.objectContaining({
-              message: errorObj.message,
-              stack: errorObj.stack,
-            }),
-          }
+          { errorDetails: {} }
         );
       });
 
@@ -590,7 +585,7 @@ describe(`${Swampyer.prototype.register.name}()`, () => {
       });
 
       it('handles arbitrary thrown object', async () => {
-        const errorObj = { a: 1, b: 2 };
+        const errorObj = { a: 1, b: 2, c: { d: 3, e: 4 }, f: [5, 6, { g: 7 }, [8, 9]] };
         const regHandler = jest.fn().mockImplementation(async () => { throw errorObj });
         await testErrorHandling(
           regHandler,
@@ -631,12 +626,7 @@ describe(`${Swampyer.prototype.register.name}()`, () => {
         await testErrorHandling(
           regHandler,
           [String(errorObj)],
-          {
-            errorDetails: expect.objectContaining({
-              message: errorObj.message,
-              stack: errorObj.stack,
-            }),
-          }
+          { errorDetails: {} }
         );
       });
 
@@ -651,7 +641,7 @@ describe(`${Swampyer.prototype.register.name}()`, () => {
       });
 
       it('handles arbitrary thrown object', async () => {
-        const errorObj = { a: 1, b: 2 };
+        const errorObj = { a: 1, b: 2, c: { d: 3, e: 4 }, f: [5, 6, { g: 7 }, [8, 9]] };
         const regHandler = jest.fn().mockImplementation(() => { throw errorObj });
         await testErrorHandling(
           regHandler,

--- a/src/swampyer.ts
+++ b/src/swampyer.ts
@@ -26,8 +26,8 @@ export class Swampyer {
   private registrationRequestId = 1;
   private unregistrationRequestId = 1;
 
-  private subscriptionHandlers: { [subscriptionId: number]: { uri: string, handler: SubscriptionHandler } } = {};
-  private registrationHandlers: { [registrationId: number]: { uri: string, handler: RegistrationHandler } } = {};
+  private subscriptionHandlers: { [subscriptionId: number]: { uri: string; handler: SubscriptionHandler } } = {};
+  private registrationHandlers: { [registrationId: number]: { uri: string; handler: RegistrationHandler } } = {};
 
   private onCloseCleanup: (() => void)[] = [];
 
@@ -393,6 +393,7 @@ export class Swampyer {
         try {
           handler?.(args, kwargs, details);
         } catch (e) {
+          // eslint-disable-next-line no-console
           console.error(`An unhandled error occurred while running subscription handler for "${uri}"`, e);
         }
         break;
@@ -409,6 +410,7 @@ export class Swampyer {
           Promise.resolve((async () => handler(args, kwargs, details))())
             .then(result => this.transport!._send(MessageTypes.Yield, [requestId, {}, [result], {}]))
             .catch(e => {
+              // eslint-disable-next-line no-console
               console.error(`An unhandled error occurred while running registration handler for "${uri}"`, e);
               this.transport!._send(
                 MessageTypes.Error,

--- a/src/swampyer.ts
+++ b/src/swampyer.ts
@@ -407,11 +407,7 @@ export class Swampyer {
             .then(result => this.transport!._send(MessageTypes.Yield, [requestId, {}, [result], {}]))
             .catch(e => this.transport!._send(
               MessageTypes.Error,
-              [
-                MessageTypes.Invocation, requestId, {}, 'error.invoke.failure',
-                [String(e)],
-                { errorDetails: JSON.parse(JSON.stringify(e)) },
-              ]
+              [MessageTypes.Invocation, requestId, {}, 'error.invoke.failure', [String(e)], { errorDetails: e }]
             ));
         }
         break;

--- a/src/swampyer.ts
+++ b/src/swampyer.ts
@@ -26,8 +26,8 @@ export class Swampyer {
   private registrationRequestId = 1;
   private unregistrationRequestId = 1;
 
-  private subscriptionHandlers: { [subscriptionId: number]: { uri: string, handler: SubscriptionHandler, options: SubscribeOptions } } = {};
-  private registrationHandlers: { [registrationId: number]: { uri: string, handler: RegistrationHandler, options: RegisterOptions } } = {};
+  private subscriptionHandlers: { [subscriptionId: number]: { uri: string, handler: SubscriptionHandler } } = {};
+  private registrationHandlers: { [registrationId: number]: { uri: string, handler: RegistrationHandler } } = {};
 
   private onCloseCleanup: (() => void)[] = [];
 
@@ -253,7 +253,7 @@ export class Swampyer {
     const requestId = this.registrationRequestId;
     this.registrationRequestId += 1;
     const [, registrationId] = await this.sendRequest(MessageTypes.Register, [requestId, options, fullUri], MessageTypes.Registered);
-    this.registrationHandlers[registrationId] = { uri, handler, options };
+    this.registrationHandlers[registrationId] = { uri, handler };
     return registrationId;
   }
 
@@ -310,7 +310,7 @@ export class Swampyer {
     const fullUri = options.withoutUriBase ? uri : this.getFullUri(uri);
     const requestId = generateRandomInt();
     const [, subscriptionId] = await this.sendRequest(MessageTypes.Subscribe, [requestId, options, fullUri], MessageTypes.Subscribed);
-    this.subscriptionHandlers[subscriptionId] = { uri, handler, options };
+    this.subscriptionHandlers[subscriptionId] = { uri, handler };
     return subscriptionId;
   }
 

--- a/src/swampyer.ts
+++ b/src/swampyer.ts
@@ -408,8 +408,9 @@ export class Swampyer {
             .catch(e => this.transport!._send(
               MessageTypes.Error,
               [
-                MessageTypes.Invocation, requestId, {}, 'error.invoke.failure', [String(e)],
-                { errorDetails: JSON.parse(JSON.stringify(e, Object.getOwnPropertyNames(e))) },
+                MessageTypes.Invocation, requestId, {}, 'error.invoke.failure',
+                [String(e)],
+                { errorDetails: JSON.parse(JSON.stringify(e)) },
               ]
             ));
         }

--- a/src/swampyer.ts
+++ b/src/swampyer.ts
@@ -26,8 +26,8 @@ export class Swampyer {
   private registrationRequestId = 1;
   private unregistrationRequestId = 1;
 
-  private subscriptionHandlers: { [subscriptionId: number]: { handler: SubscriptionHandler } } = {};
-  private registrationHandlers: { [registrationId: number]: { handler: RegistrationHandler } } = {};
+  private subscriptionHandlers: { [subscriptionId: number]: { uri: string, handler: SubscriptionHandler, options: SubscribeOptions } } = {};
+  private registrationHandlers: { [registrationId: number]: { uri: string, handler: RegistrationHandler, options: RegisterOptions } } = {};
 
   private onCloseCleanup: (() => void)[] = [];
 
@@ -253,7 +253,7 @@ export class Swampyer {
     const requestId = this.registrationRequestId;
     this.registrationRequestId += 1;
     const [, registrationId] = await this.sendRequest(MessageTypes.Register, [requestId, options, fullUri], MessageTypes.Registered);
-    this.registrationHandlers[registrationId] = { handler };
+    this.registrationHandlers[registrationId] = { uri, handler, options };
     return registrationId;
   }
 
@@ -310,7 +310,7 @@ export class Swampyer {
     const fullUri = options.withoutUriBase ? uri : this.getFullUri(uri);
     const requestId = generateRandomInt();
     const [, subscriptionId] = await this.sendRequest(MessageTypes.Subscribe, [requestId, options, fullUri], MessageTypes.Subscribed);
-    this.subscriptionHandlers[subscriptionId] = { handler };
+    this.subscriptionHandlers[subscriptionId] = { uri, handler, options };
     return subscriptionId;
   }
 
@@ -396,7 +396,7 @@ export class Swampyer {
       }
       case MessageTypes.Invocation: {
         const [requestId, registrationId, details, args, kwargs] = data as MessageData[MessageTypes.Invocation];
-        const { handler } = this.registrationHandlers[registrationId];
+        const { handler, options } = this.registrationHandlers[registrationId];
         if (!handler) {
           this.transport!._send(
             MessageTypes.Error,


### PR DESCRIPTION
- The previous way to do it meant that I was able to extract more details out of the normal `Error` objects
  - But, turns out, that methods does not work if you have nested objects. It would just drop the nested objects unfortunately
  - So, I just decided to simplify things
    - We no longer get the hidden details from the `Error` object
    - But, I guess that those details were never intended to be used openly like this anyway, so it should be okay if it is not transmitted to the caller
    - Any additional things in the `Error` object will show up though