### PR TITLE
Make the `SwampyerError` class extend the `Error` class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swampyer",
-  "version": "1.4.3",
+  "version": "1.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "swampyer",
-      "version": "1.4.3",
+      "version": "1.5.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swampyer",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A lightweight WAMP client implementing the WAMP v2 basic profile",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,10 +1,4 @@
-export class SwampyerError {
-  constructor(public readonly message?: string) {}
-
-  toString() {
-    return this.message;
-  }
-}
+export class SwampyerError extends Error {}
 
 export class SwampyerOperationError extends SwampyerError {
   constructor(


### PR DESCRIPTION
- This will allow users to generically handle the errors without having to care about whether it is specifically a `SwampyerError`. They can just check if an error is an instance of the `Error` class