### PR TITLE
Add new `callWithResult()` method to `Swampyer` class

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,6 +30,10 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      # Required for publishing to npm using "Trusted Publisher" OIDC authentication
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -42,6 +46,4 @@ jobs:
         with:
           path: ./lib
           key: ${{ github.sha }}
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+      - run: npm publish --provenance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swampyer",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "swampyer",
-      "version": "1.5.2",
+      "version": "1.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swampyer",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "A lightweight WAMP client implementing the WAMP v2 basic profile",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/swampyer.test.ts
+++ b/src/swampyer.test.ts
@@ -745,6 +745,8 @@ describe(`${Swampyer.prototype.callWithResult.name}()`, () => {
   const args = ['my_args'];
   const kwargs = { my: 'kwargs' };
 
+  const resultDetails = { someWampInfo: 'info' };
+
   beforeEach(async () => {
     await openWamp();
   });
@@ -753,8 +755,8 @@ describe(`${Swampyer.prototype.callWithResult.name}()`, () => {
     const promise = wamp.callWithResult('com.test.something', args, kwargs);
     const request = await transportProvider.transport.read();
     expect(request).toEqual([MessageTypes.Call, expect.any(Number), {}, 'com.test.something', args, kwargs]);
-    transportProvider.sendToLib(MessageTypes.Result, [request[1] as number, { someWampInfo: 'info' }, ['something'], { something: 'else' }]);
-    expect(await promise).toEqual([['something'], { something: 'else' }, { someWampInfo: 'info' }]);
+    transportProvider.sendToLib(MessageTypes.Result, [request[1] as number, resultDetails, ['something'], { something: 'else' }]);
+    expect(await promise).toEqual([['something'], { something: 'else' }, resultDetails]);
   });
 
   it('throws an error if the call request fails', async () => {

--- a/src/swampyer.ts
+++ b/src/swampyer.ts
@@ -272,7 +272,7 @@ export class Swampyer {
   }
 
   /**
-   * Call a WAMP URI and returns the full result
+   * Call a WAMP URI and get the full result
    *
    * @param uri The WAMP URI to call
    *
@@ -302,7 +302,10 @@ export class Swampyer {
   }
 
   /**
-   * Call a WAMP URI and get its result
+   * Call a WAMP URI and get the `args[0]` value from the result directly. This is convenient
+   * if the WAMP URI only ever returns useful data via the first positional argument.
+   * 
+   * If you need access to the full result then use {@link callWithResult callWithResult()} instead.
    *
    * @param uri The WAMP URI to call
    *

--- a/src/swampyer.ts
+++ b/src/swampyer.ts
@@ -281,14 +281,14 @@ export class Swampyer {
    * @param args Positional arguments
    * @param kwargs Keyword arguments
    * @param options Settings for how the registration should be done. This may vary between WAMP servers
-   * @returns A tuple containing the raw `args`, `kwargs` and the WAMP call `details`
+   * @returns A tuple containing the raw `args`, `kwargs` and the WAMP call's result `details`
    */
   async callWithResult(
     uri: string,
     args: unknown[] = [],
     kwargs: Object = {},
     options: CallOptions = {}
-  ): Promise<[args: unknown[], kwargs: Object, wampCallResponseDetails: Object]> {
+  ): Promise<[args: unknown[], kwargs: Object, wampCallResultDetails: Object]> {
     this.throwIfNotOpen();
     const fullUri = options.withoutUriBase ? uri : this.getFullUri(uri);
     const requestId = this.callRequestId;
@@ -314,7 +314,7 @@ export class Swampyer {
    * @param args Positional arguments
    * @param kwargs Keyword arguments
    * @param options Settings for how the registration should be done. This may vary between WAMP servers
-   * @returns Arbitrary data returned by the call operation
+   * @returns Arbitrary data defined at the `args[0]` value in the call operation's result
    */
   async call(uri: string, args: unknown[] = [], kwargs: Object = {}, options: CallOptions = {}): Promise<unknown> {
     const [resultArray] = await this.callWithResult(uri, args, kwargs, options);

--- a/src/swampyer.ts
+++ b/src/swampyer.ts
@@ -304,7 +304,7 @@ export class Swampyer {
   /**
    * Call a WAMP URI and get the `args[0]` value from the result directly. This is convenient
    * if the WAMP URI only ever returns useful data via the first positional argument.
-   * 
+   *
    * If you need access to the full result then use {@link callWithResult callWithResult()} instead.
    *
    * @param uri The WAMP URI to call


### PR DESCRIPTION
This new `callWithResult()` method returns the `args`, `kwargs` and `details` data about the WAMP call's result.

The existing `call()` method now uses this new method under the hood but continues to only return `args[0]` values from the WAMP call's result.